### PR TITLE
Enhance skills section with i18n and filters

### DIFF
--- a/app/components/SkillCard.js
+++ b/app/components/SkillCard.js
@@ -1,0 +1,26 @@
+import { FaStar } from 'react-icons/fa';
+
+export default function SkillCard({ icon, name, description, level, lang, translations }) {
+    const levelLabel = translations[lang]?.levels[level - 1] || '';
+
+    return (
+        <div
+            title={name}
+            className="w-full h-full bg-slate-100 dark:bg-slate-800 rounded-lg shadow-md p-6
+            flex flex-col items-center justify-between hover:scale-105 transition-transform duration-300"
+        >
+            <div className="mb-4">{icon}</div>
+            <h4 className="text-lg font-bold text-black dark:text-white text-center mt-1">{name}</h4>
+            <p className="text-sm text-gray-700 dark:text-gray-300 text-center mt-1">{description}</p>
+            <div className="flex justify-center mt-3">
+                {[...Array(5)].map((_, i) => (
+                    <FaStar
+                        key={i}
+                        className={`w-4 h-4 ${i < level ? 'text-yellow-400' : 'text-gray-300'}`}
+                    />
+                ))}
+            </div>
+            <p className="text-xs text-gray-500 mt-1">{levelLabel}</p>
+        </div>
+    );
+}

--- a/app/components/Skills.js
+++ b/app/components/Skills.js
@@ -1,58 +1,216 @@
-import { SiRuby, SiFlutter, SiUnity } from 'react-icons/si';
-import { FaJsSquare, FaReact, FaNodeJs, FaGitAlt, FaHtml5, FaCss3Alt } from 'react-icons/fa';
+import {
+  SiRuby,
+  SiFlutter,
+  SiUnity,
+  SiNextdotjs,
+  SiTypescript,
+  SiDart,
+  SiCsharp,
+  SiRubyonrails,
+  SiReact,
+  SiGit,
+  SiGithub,
+  SiVercel,
+  SiAutodesk,
+  SiMysql,
+  SiSqlite,
+  SiHtml5,
+  SiCss3,
+} from 'react-icons/si';
+import { FaJsSquare } from 'react-icons/fa';
+import { useState } from 'react';
+import SkillCard from './SkillCard';
+import { translations } from '../i18n/translations';
 
-export default function Skills() {
+export default function Skills({ lang = 'en' }) {
+  const [activeCategory, setActiveCategory] = useState('All');
+
+  const allCategories = [
+    {
+      name: 'Languages',
+      id: 'languages',
+      items: [
+        {
+          name: 'HTML & CSS',
+          icon: (
+            <div className="flex justify-center space-x-2">
+              <SiHtml5 className="text-orange-500 w-8 h-8" />
+              <SiCss3 className="text-blue-500 w-8 h-8" />
+            </div>
+          ),
+          description: 'Markup & Styling',
+          level: 3,
+        },
+        {
+          name: 'JavaScript',
+          icon: <FaJsSquare className="text-yellow-500 w-8 h-8" />,
+          description: 'ES6+',
+          level: 3,
+        },
+        {
+          name: 'TypeScript',
+          icon: <SiTypescript className="text-blue-600 w-8 h-8" />,
+          description: 'Static Typing',
+          level: 3,
+        },
+        {
+          name: 'Dart',
+          icon: <SiDart className="text-blue-400 w-8 h-8" />,
+          description: 'Flutter Language',
+          level: 4,
+        },
+        {
+          name: 'Ruby',
+          icon: <SiRuby className="text-red-500 w-8 h-8" />,
+          description: 'Web Development',
+          level: 4,
+        },
+        {
+          name: 'C#',
+          icon: <SiCsharp className="text-green-600 w-8 h-8" />,
+          description: 'Game Development',
+          level: 2,
+        },
+      ],
+    },
+    {
+      name: 'Frameworks',
+      id: 'frameworks',
+      items: [
+        {
+          name: 'Ruby on Rails',
+          icon: <SiRubyonrails className="text-red-600 w-8 h-8" />,
+          description: 'MVC',
+          level: 4,
+        },
+        {
+          name: 'Flutter',
+          icon: <SiFlutter className="text-blue-400 w-8 h-8" />,
+          description: 'Cross-platform',
+          level: 4,
+        },
+        {
+          name: 'Next.js',
+          icon: <SiNextdotjs className="text-black dark:text-white w-8 h-8" />,
+          description: 'React Framework',
+          level: 3,
+        },
+        {
+          name: 'React',
+          icon: <SiReact className="text-blue-500 w-8 h-8" />,
+          description: 'UI Library',
+          level: 2,
+        },
+      ],
+    },
+    {
+      name: 'GameEngine',
+      id: 'game-engine',
+      items: [
+        {
+          name: 'Unity',
+          icon: <SiUnity className="text-gray-800 w-8 h-8" />,
+          description: 'Game Engine',
+          level: 3,
+        },
+        {
+          name: 'MotionBuilder',
+          icon: <SiAutodesk className="text-green-600 w-8 h-8" />,
+          description: 'Mocap Animation',
+          level: 2,
+        },
+      ],
+    },
+    {
+      name: 'Tools',
+      id: 'tools',
+      items: [
+        {
+          name: 'Git & GitHub',
+          icon: (
+            <div className="flex justify-center space-x-2">
+              <SiGit className="text-orange-500 w-8 h-8" />
+              <SiGithub className="text-black dark:text-white w-8 h-8" />
+            </div>
+          ),
+          description: 'Version Control',
+          level: 4,
+        },
+        {
+          name: 'Vercel',
+          icon: <SiVercel className="text-black dark:text-white w-8 h-8" />,
+          description: 'Deployment',
+          level: 3,
+        },
+      ],
+    },
+    {
+      name: 'Databases',
+      id: 'databases',
+      items: [
+        {
+          name: 'MySQL',
+          icon: <SiMysql className="text-blue-700 w-8 h-8" />,
+          description: 'Relational DB',
+          level: 1,
+        },
+        {
+          name: 'SQLite',
+          icon: <SiSqlite className="text-blue-500 w-8 h-8" />,
+          description: 'Lightweight DB',
+          level: 1,
+        },
+      ],
+    },
+  ];
+
+  const filteredCategories = activeCategory === 'All'
+    ? allCategories
+    : allCategories.filter((c) => c.name === activeCategory);
+
+  const categoryNames = ['All', ...allCategories.map((c) => c.name)];
+
   return (
-    <section id="skills" className="my-16">
-      <h2 className="text-4xl font-bold mb-6 text-black dark:text-white">Skills & Technologies</h2>
-      <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8 text-center">
-        {/* 技術スキルセクション */}
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <SiRuby className="text-red-500 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">Ruby on Rails</h3>
-          <p className="text-gray-700 dark:text-gray-300">MVC, RESTful API</p>
-        </div>
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <FaJsSquare className="text-yellow-500 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">JavaScript</h3>
-          <p className="text-gray-700 dark:text-gray-300">ES6, TypeScript</p>
-        </div>
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <FaReact className="text-blue-500 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">React</h3>
-          <p className="text-gray-700 dark:text-gray-300">Hooks, Context API</p>
-        </div>
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <FaNodeJs className="text-green-500 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">Node.js</h3>
-          <p className="text-gray-700 dark:text-gray-300">Express.js, REST APIs</p>
-        </div>
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <FaGitAlt className="text-orange-500 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">Git & GitHub</h3>
-          <p className="text-gray-700 dark:text-gray-300">Version Control</p>
-        </div>
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <FaHtml5 className="text-orange-600 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">HTML5</h3>
-          <p className="text-gray-700 dark:text-gray-300">Semantic HTML</p>
-        </div>
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <FaCss3Alt className="text-blue-500 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">CSS3</h3>
-          <p className="text-gray-700 dark:text-gray-300">Responsive Design</p>
-        </div>
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <SiFlutter className="text-blue-400 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">Flutter</h3>
-          <p className="text-gray-700 dark:text-gray-300">Cross-platform</p>
-        </div>
-        <div className="p-4 bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 transition">
-          <SiUnity className="text-gray-800 w-16 h-16 mx-auto mb-4" />
-          <h3 className="text-2xl font-bold text-black dark:text-white">Unity</h3>
-          <p className="text-gray-700 dark:text-gray-300">Game Development</p>
-        </div>
+    <section id="skills" className="my-16 px-4">
+      <h2 className="text-4xl font-bold mb-6 text-black dark:text-white text-left">
+        Skills & Technologies
+      </h2>
+
+      {/* Filter Buttons */}
+      <div className="flex flex-wrap gap-3 justify-start mb-10">
+        {categoryNames.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setActiveCategory(cat)}
+            className={`px-4 py-2 rounded-full text-sm font-semibold transition
+        ${activeCategory === cat
+                ? 'bg-indigo-600 text-white'
+                : 'bg-gray-200 dark:bg-gray-700 text-black dark:text-white'
+              }`}
+          >
+            {translations[lang]?.categories[cat] || cat}
+          </button>
+        ))}
       </div>
+
+      {/* Skills Grid */}
+      {filteredCategories.map((category) => (
+        <div key={category.name} id={category.id} className="mb-12">
+          <h3 className="text-2xl font-semibold mb-6 text-black dark:text-white text-left">
+            {translations[lang]?.categories[category.name] || category.name}
+          </h3>
+          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            {category.items.map((skill) => (
+              <SkillCard
+                key={skill.name}
+                {...skill}
+                lang={lang}
+                translations={translations}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
     </section>
   );
 }

--- a/app/i18n/translations.js
+++ b/app/i18n/translations.js
@@ -1,0 +1,22 @@
+export const translations = {
+    en: {
+        categories: {
+            Languages: 'Languages',
+            Frameworks: 'Frameworks',
+            GameEngine: 'Game Engine & Animation',
+            Tools: 'Tools',
+            Databases: 'Databases',
+        },
+        levels: ['Beginner', 'Beginner', 'Intermediate', 'Advanced', 'Expert'],
+    },
+    ja: {
+        categories: {
+            Languages: '言語',
+            Frameworks: 'フレームワーク',
+            Tools: 'ツール',
+            GameEngine: 'ゲームエンジンとアニメーション',
+            Databases: 'データベース',
+        },
+        levels: ['初心者', '初心者', '中級', '上級', 'エキスパート'],
+    },
+};


### PR DESCRIPTION
## Summary
- restore filterable skill categories with MotionBuilder and localization
- add SkillCard tooltip, star ratings, and proficiency labels
- introduce translations file for English and Japanese categories

## Testing
- `npm run lint` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4dddddc0832dbdd3b0cc073e9a3b