### PR TITLE
Removed animation and changed color design of skill section

### DIFF
--- a/app/components/SkillCard.js
+++ b/app/components/SkillCard.js
@@ -6,12 +6,11 @@ export default function SkillCard({ icon, name, description, level, lang, transl
     return (
         <div
             title={name}
-            className="w-full h-full bg-slate-100 dark:bg-slate-800 rounded-lg shadow-md p-6
-            flex flex-col items-center justify-between hover:scale-105 transition-transform duration-300"
+            className="w-full h-full bg-yellow-50 dark:bg-black border border-yellow-400 rounded-lg shadow-md p-6 flex flex-col items-center justify-between"
         >
             <div className="mb-4">{icon}</div>
-            <h4 className="text-lg font-bold text-black dark:text-white text-center mt-1">{name}</h4>
-            <p className="text-sm text-gray-700 dark:text-gray-300 text-center mt-1">{description}</p>
+            <h4 className="text-lg font-bold text-black dark:text-yellow-300 text-center mt-1">{name}</h4>
+            <p className="text-sm text-black dark:text-yellow-100 text-center mt-1">{description}</p>
             <div className="flex justify-center mt-3">
                 {[...Array(5)].map((_, i) => (
                     <FaStar
@@ -20,7 +19,7 @@ export default function SkillCard({ icon, name, description, level, lang, transl
                     />
                 ))}
             </div>
-            <p className="text-xs text-gray-500 mt-1">{levelLabel}</p>
+            <p className="text-xs text-yellow-700 dark:text-yellow-400 mt-1">{levelLabel}</p>
         </div>
     );
 }

--- a/app/components/Skills.js
+++ b/app/components/Skills.js
@@ -92,7 +92,7 @@ export default function Skills({ lang = 'en' }) {
         },
         {
           name: 'Next.js',
-          icon: <SiNextdotjs className="text-black dark:text-white w-8 h-8" />,
+          icon: <SiNextdotjs className="text-black dark:text-yellow-400 w-8 h-8" />,
           description: 'React Framework',
           level: 3,
         },
@@ -131,7 +131,7 @@ export default function Skills({ lang = 'en' }) {
           icon: (
             <div className="flex justify-center space-x-2">
               <SiGit className="text-orange-500 w-8 h-8" />
-              <SiGithub className="text-black dark:text-white w-8 h-8" />
+              <SiGithub className="text-black dark:text-yellow-400 w-8 h-8" />
             </div>
           ),
           description: 'Version Control',
@@ -139,7 +139,7 @@ export default function Skills({ lang = 'en' }) {
         },
         {
           name: 'Vercel',
-          icon: <SiVercel className="text-black dark:text-white w-8 h-8" />,
+          icon: <SiVercel className="text-black dark:text-yellow-400 w-8 h-8" />,
           description: 'Deployment',
           level: 3,
         },
@@ -183,10 +183,10 @@ export default function Skills({ lang = 'en' }) {
           <button
             key={cat}
             onClick={() => setActiveCategory(cat)}
-            className={`px-4 py-2 rounded-full text-sm font-semibold transition
+            className={`px-4 py-2 rounded-full text-sm font-semibold border transition-colors
         ${activeCategory === cat
-                ? 'bg-indigo-600 text-white'
-                : 'bg-gray-200 dark:bg-gray-700 text-black dark:text-white'
+                ? 'bg-yellow-400 text-black border-yellow-400'
+                : 'bg-gray-200 text-black border-yellow-400 dark:bg-black dark:text-yellow-400'
               }`}
           >
             {translations[lang]?.categories[cat] || cat}


### PR DESCRIPTION
### 背景/目的  
ポートフォリオのスキルカードやスキル一覧のデザイン性・視認性向上、およびダークモード対応の強化を目的としてUIの配色やスタイルを改善しました。

### issue  
[#15](https://github.com/hamasaki-code/My-portfolio/issues/15)

### 実装内容  
- SkillCardコンポーネントの背景色、枠線、テキストカラーの変更（明るい黄色系を基調、ダークモード時は黒背景＋黄色系テキスト）。
- スキルレベルラベルのカラー変更。
- Skillsコンポーネント内でNext.js・GitHub・Vercelアイコンのダークモード時の色を黄色系に変更。
- スキルカテゴリのタブボタンのカラーと境界線を黄色系に変更し、ダークモード時のアクセントカラーを統一。

### 方法  
- SkillCard.js・Skills.jsの各種className値（Tailwind CSS）を変更し、デザインを黄色系＋黒基調に統一。
- ダークモード時のテキストや背景のカラー値を黄色系・黒系に変更。
- スキルアイコン部分のclassNameを調整し、ダークモード時にアクセントカラーが映えるように修正。
- タブボタンの選択状態・未選択状態のスタイルを変更し、視認性を高めた。

### 変更箇所  
- app/components/SkillCard.js  
- app/components/Skills.js  

### その他・補足  
- 今回の変更はUI/UX向上を目的としており、機能面・ロジック面の変更はありません。
- Tailwind CSSのユーティリティクラスによるスタイル変更のみです。
- 他のコンポーネントや機能への影響はありません。  
- デザイン基調（黄色＋黒）は今後の他ページにも展開予定です。
