### PR TITLE
Added ability to show or hide header

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -1,11 +1,17 @@
 "use client";
 import { useState } from 'react';
+import useScrollDirection from '../hooks/useScrollDirection';
 
 export default function Header({ toggleDarkMode, isDarkMode }) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const scrollDirection = useScrollDirection();
 
   return (
-    <header className="bg-yellow-400 dark:bg-gray-800 text-black dark:text-white p-6 border-b-4 border-black dark:border-white">
+    <header
+      className={`fixed top-0 w-full z-50 bg-yellow-400 dark:bg-gray-800 text-black dark:text-white p-6 border-b-4 border-black
+                  dark:border-white transform transition-transform transition-opacity duration-500 ease-in-out
+                  ${scrollDirection === 'down' && !menuOpen ? '-translate-y-full opacity-0' : 'translate-y-0 opacity-100'}`}
+    >
       <nav className="container mx-auto flex justify-between items-center">
         <h1 className="text-4xl font-extrabold tracking-wider">My Portfolio</h1>
 

--- a/app/hooks/useScrollDirection.js
+++ b/app/hooks/useScrollDirection.js
@@ -1,0 +1,25 @@
+"use client";
+import { useState, useEffect } from 'react';
+
+export default function useScrollDirection() {
+    const [direction, setDirection] = useState('up');
+
+    useEffect(() => {
+        let lastY = window.scrollY;
+        const threshold = 50;
+
+        const handleScroll = () => {
+            const currentY = window.scrollY;
+            const diff = currentY - lastY;
+            if (Math.abs(diff) > threshold) {
+                setDirection(diff > 0 ? 'down' : 'up');
+                lastY = currentY;
+            }
+        };
+
+        window.addEventListener('scroll', handleScroll, { passive: true });
+        return () => window.removeEventListener('scroll', handleScroll);
+    }, []);
+
+    return direction;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
     <div className={`min-h-screen ${isDarkMode ? 'dark' : ''}`}>
       <SeoHead />
       <Header toggleDarkMode={toggleDarkMode} isDarkMode={isDarkMode} />
-      <main className="container mx-auto p-6 bg-white dark:bg-gray-900">
+      <main className="container mx-auto p-6 pt-24 bg-white dark:bg-gray-900">
         <About />
         <Projects />
         <Skills />


### PR DESCRIPTION
## isuue  
[#14](https://github.com/hamasaki-code/My-portfolio/issues/14)

## 背景/目的  
ユーザーがページを下にスクロールした際にヘッダーを一時的に非表示にすることで、表示領域を広げ、コンテンツ閲覧の邪魔にならないようUXを向上させることが目的です。上にスクロールした際はヘッダーを再表示することで、ナビゲーションへのアクセス性も維持します。

## 実装内容  
- ユーザーのスクロール方向（上/下）を判定するカスタムフック `useScrollDirection` を新規作成。
- ヘッダーの表示/非表示をスクロール方向に応じて切り替えるように改修。
- ヘッダー表示/非表示のアニメーションを追加（transform, opacity, transition）。

## 方法  
1. `app/hooks/useScrollDirection.js` を新規作成し、スクロール方向を判定するカスタムフックを実装。
2. `Header` コンポーネントで `useScrollDirection` を利用し、`scrollDirection` に応じてヘッダーのクラス（transform/opacity）を制御。
3. ヘッダーを `fixed` にし、スクロールで非表示時は `-translate-y-full opacity-0`、表示時は `translate-y-0 opacity-100` を適用。
4. メニューが開いている場合は常にヘッダーを表示。

## 変更箇所  
- `app/components/Header.js`  
  - `useScrollDirection` の導入  
  - ヘッダーのクラス制御ロジック追加  
- `app/hooks/useScrollDirection.js`  
  - 新規作成：スクロール方向判定用カスタムフック
- `app/page.tsx`  
  - `<main>` の padding-top を増やし、`fixed` ヘッダー分のスペースを確保（`pt-24` に変更）