### PR TITLE
Highlight current job node and adjust DMM/LITALICO node positions

### DIFF
--- a/app/components/Career.tsx
+++ b/app/components/Career.tsx
@@ -20,7 +20,8 @@ export default function Career() {
 
           <div className="space-y-12">
             <article className="relative pl-16">
-              <div className="absolute left-0 top-0 flex h-12 w-12 items-center justify-center rounded-full bg-yellow-400 text-black shadow-md ring-4 ring-white/50 dark:bg-yellow-400 dark:text-black dark:ring-yellow-500/20">
+              <div className="absolute left-0 top-0 flex h-12 w-12 items-center justify-center rounded-full 
+  bg-yellow-400 text-black shadow-md ring-4 ring-green-400/60 dark:bg-yellow-400 dark:text-black dark:ring-green-400/40">
                 <FaBuilding className="h-5 w-5" />
               </div>
               <time className="text-xs font-semibold uppercase tracking-[0.2em] text-yellow-700 dark:text-yellow-300">
@@ -70,7 +71,7 @@ export default function Career() {
             </article>
 
             <article className="relative pl-16">
-              <div className="absolute left-1.5 top-1.5 h-3 w-3 -translate-x-1/2 rounded-full bg-yellow-400 ring-[6px] ring-white/70 shadow-sm dark:ring-yellow-500/30" />
+              <div className="absolute left-5 top-1.5 h-3 w-3 -translate-x-1/2 rounded-full bg-yellow-400 ring-[6px] ring-white/70 shadow-sm dark:ring-yellow-500/30" />
               <time className="text-xs font-semibold uppercase tracking-[0.2em] text-yellow-700 dark:text-yellow-300">
                 2023年6月 - 2024年3月
               </time>
@@ -85,7 +86,7 @@ export default function Career() {
             </article>
 
             <article className="relative pl-16">
-              <div className="absolute left-1.5 top-1.5 h-3 w-3 -translate-x-1/2 rounded-full bg-yellow-400 ring-[6px] ring-white/70 shadow-sm dark:ring-yellow-500/30" />
+              <div className="absolute left-5 top-1.5 h-3 w-3 -translate-x-1/2 rounded-full bg-yellow-400 ring-[6px] ring-white/70 shadow-sm dark:ring-yellow-500/30" />
               <time className="text-xs font-semibold uppercase tracking-[0.2em] text-yellow-700 dark:text-yellow-300">
                 2021年4月 - 2023年11月
               </time>


### PR DESCRIPTION
## Issue

[#39](https://github.com/hamasaki-code/My-portfolio/issues/39)

## 背景/目的

* キャリアタイムラインにおいて「現在勤めている会社」をより強調したい。
* DMM と LITALICO のノード点の位置が他と微妙にずれていたため、視覚的なバランスを改善する。


## 実装内容

* 現在勤務中の会社アイコンの外枠リングを **グリーン系カラー** に変更し、他と差別化。
* DMM と LITALICO のノード点の位置を **微調整** し、ラインとの整合性を改善。


## 方法

* Tailwind CSS の `ring-green-400/60` および `dark:ring-green-400/40` を使用し、外枠を変更。
* 対象ノードの `left` / `top` の値を微調整し、配置を統一感のあるものに修正。


## 変更箇所

* `app/components/Career.tsx`

  * 現在勤務中のノード：外枠のリングカラーをグリーン系に変更
  * DMM, LITALICO ノード：点の位置を調整


## まとめ

* 現在の職務が一目でわかるように強調。
* ノード全体のデザインバランスを整えることで、タイムラインの視認性を向上。
