### PR TITLE
Improve reCAPTCHA script loading

### DIFF
--- a/app/api/email/route.tsx
+++ b/app/api/email/route.tsx
@@ -6,7 +6,9 @@ const rateLimitMap = new Map<string, number>()
 export async function POST(req: Request) {
     try {
         const { name, email, message, captcha } = await req.json()
-        const requireCaptcha = !!process.env.RECAPTCHA_SECRET_KEY
+        const captchaSecret = process.env.RECAPTCHA_SECRET_KEY
+        const captchaSiteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+        const requireCaptcha = Boolean(captchaSecret && captchaSiteKey)
 
         if (!name || !email || !message || (requireCaptcha && !captcha)) {
             return NextResponse.json(
@@ -32,7 +34,7 @@ export async function POST(req: Request) {
                 headers: {
                     "Content-Type": "application/x-www-form-urlencoded",
                 },
-                body: `secret=${process.env.RECAPTCHA_SECRET_KEY}&response=${captcha}`,
+                body: `secret=${captchaSecret}&response=${captcha}`,
             })
             const captchaData = await captchaRes.json()
             if (!captchaData.success) {


### PR DESCRIPTION
## Issue
[#49](https://github.com/hamasaki-code/My-portfolio/issues/49)


## 背景/目的

* reCAPTCHA ウィジェットの初期化が不安定で、トークンが取得できず送信ボタンが無効化されるケースが発生していた。
* 開発環境やキー未設定時にもフォームが動作するよう、API 側の reCAPTCHA 検証を柔軟化する必要があった。


## 実装内容

* **フロントエンド**

  * reCAPTCHA を `Next.js <Script>` コンポーネント経由で遅延ロードし、一度だけ描画されるよう制御。
  * トークン取得・期限切れ・読み込み失敗を検知し、状態管理とユーザー向けエラーメッセージを追加。
  * `useCallback` + `useEffect` でウィジェット描画とクリーンアップを一元管理し、重複レンダリングを防止。
* **バックエンド**

  * `app/api/email/route.tsx` で環境変数をチェックし、公開鍵と秘密鍵が揃っている場合のみ Google の `siteverify` を呼び出すよう条件分岐を追加。


## 方法

* reCAPTCHA スクリプトを `<Script>` コンポーネントで遅延ロード。
* 読み込み成功時に `renderWidget` を実行、失敗時には再読み込みを促すメッセージを表示。
* API 側ではリクエストボディと環境変数を検証した上で、必要な場合のみ `siteverify` へ POST。


## 変更箇所

* `app/components/Recaptcha.tsx` : reCAPTCHA のロード・描画・エラー処理を再実装。
* `app/api/email/route.tsx` : reCAPTCHA 検証を条件付きで実行するロジックを追加。


## まとめ

* フロントエンドでの reCAPTCHA 読み込みとトークン管理を堅牢化し、失敗時のリカバリー手段を実装。
* バックエンドでの検証処理を柔軟化し、開発環境やキー未設定時でもフォームが利用可能になった。


## Testing

✅ `npm run lint` 