### PR TITLE
Improve reCAPTCHA integration for invisible widget support

### DIFF
--- a/app/components/Recaptcha.tsx
+++ b/app/components/Recaptcha.tsx
@@ -99,7 +99,6 @@ const Recaptcha = forwardRef<RecaptchaHandle, { onChange: (token: string | null)
 
             const api = getApi()
             api?.reset?.(widgetIdRef.current)
-            widgetIdRef.current = null
             lastTokenRef.current = null
         }, [getApi])
 

--- a/app/components/Recaptcha.tsx
+++ b/app/components/Recaptcha.tsx
@@ -98,7 +98,11 @@ const Recaptcha = forwardRef<RecaptchaHandle, { onChange: (token: string | null)
             }
 
             const api = getApi()
-            api?.reset?.(widgetIdRef.current)
+            const widgetId = widgetIdRef.current
+
+            api?.reset?.(widgetId)
+            // Preserve the widget ID so invisible widgets can execute again without re-rendering.
+            widgetIdRef.current = widgetId
             lastTokenRef.current = null
         }, [getApi])
 

--- a/app/components/Recaptcha.tsx
+++ b/app/components/Recaptcha.tsx
@@ -1,10 +1,23 @@
 "use client"
 
 import Script from "next/script"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+    forwardRef,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useMemo,
+    useRef,
+    useState,
+} from "react"
+
+type RecaptchaSize = "compact" | "normal" | "invisible"
+type RecaptchaBadge = "bottomright" | "bottomleft" | "inline"
 
 interface RecaptchaRenderOptions {
     sitekey: string
+    size?: RecaptchaSize
+    badge?: RecaptchaBadge
     callback: (token: string) => void
     "expired-callback"?: () => void
     "error-callback"?: () => void
@@ -14,7 +27,13 @@ interface RecaptchaAPI {
     ready?: (cb: () => void) => void
     render?: (container: HTMLElement, options: RecaptchaRenderOptions) => number
     reset?: (widgetId?: number) => void
+    execute?: (widgetId?: number) => PromiseLike<string> | string | void
     enterprise?: RecaptchaAPI
+}
+
+export interface RecaptchaHandle {
+    execute: () => Promise<string>
+    reset: () => void
 }
 
 declare global {
@@ -28,126 +47,230 @@ const RECAPTCHA_SCRIPT_SRC = "https://www.google.com/recaptcha/api.js?render=exp
 
 type WidgetState = "idle" | "loading" | "ready" | "error"
 
-export default function Recaptcha({ onChange }: { onChange: (token: string | null) => void }) {
-    const containerRef = useRef<HTMLDivElement>(null)
-    const widgetIdRef = useRef<number | null>(null)
-    const [state, setState] = useState<WidgetState>("idle")
-    const [error, setError] = useState<string | null>(null)
-    const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+const rawSize = process.env.NEXT_PUBLIC_RECAPTCHA_SIZE
+const RECAPTCHA_SIZE: RecaptchaSize = rawSize === "compact" || rawSize === "invisible" ? rawSize : "normal"
+const rawBadge = process.env.NEXT_PUBLIC_RECAPTCHA_BADGE
+const RECAPTCHA_BADGE: RecaptchaBadge | undefined =
+    rawBadge === "bottomleft" || rawBadge === "inline" ? rawBadge : rawBadge === "bottomright" ? "bottomright" : undefined
 
-    const scriptLoaded = useMemo(() => {
-        if (typeof window === "undefined") {
-            return false
-        }
+const Recaptcha = forwardRef<RecaptchaHandle, { onChange: (token: string | null) => void }>(
+    ({ onChange }, ref) => {
+        const containerRef = useRef<HTMLDivElement>(null)
+        const widgetIdRef = useRef<number | null>(null)
+        const pendingExecuteRef = useRef<{
+            resolve: (token: string) => void
+            reject: (error: Error) => void
+        } | null>(null)
+        const lastTokenRef = useRef<string | null>(null)
+        const [state, setState] = useState<WidgetState>("idle")
+        const [error, setError] = useState<string | null>(null)
+        const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
 
-        const api = window.grecaptcha
-        return Boolean(api?.render || api?.enterprise?.render)
-    }, [])
+        const scriptLoaded = useMemo(() => {
+            if (typeof window === "undefined") {
+                return false
+            }
 
-    const resetWidget = useCallback(() => {
-        if (widgetIdRef.current === null) {
-            return
-        }
+            const api = window.grecaptcha
+            return Boolean(api?.render || api?.enterprise?.render)
+        }, [])
 
-        const api = window.grecaptcha?.reset ? window.grecaptcha : window.grecaptcha?.enterprise
-        api?.reset?.(widgetIdRef.current)
-        widgetIdRef.current = null
-    }, [])
+        const getApi = useCallback(() => {
+            const g = window.grecaptcha
+            return g?.render || g?.execute ? g : g?.enterprise
+        }, [])
 
-    const renderWidget = useCallback(() => {
-        if (!containerRef.current || !siteKey) {
-            return
-        }
+        const resolvePending = useCallback(
+            (token: string | null, errorMessage?: string) => {
+                if (token) {
+                    pendingExecuteRef.current?.resolve(token)
+                } else if (errorMessage) {
+                    pendingExecuteRef.current?.reject(new Error(errorMessage))
+                }
+                pendingExecuteRef.current = null
+            },
+            []
+        )
 
-        const g = window.grecaptcha
-        const api = g?.render ? g : g?.enterprise
-        const ready = api?.ready || g?.ready
-        const renderFn = api?.render
-
-        if (typeof renderFn !== "function") {
-            setError("Failed to initialise reCAPTCHA widget.")
-            setState("error")
-            onChange(null)
-            return
-        }
-
-        const exec = () => {
-            if (!containerRef.current || widgetIdRef.current !== null) {
+        const resetWidget = useCallback(() => {
+            if (widgetIdRef.current === null) {
                 return
             }
 
-            widgetIdRef.current = renderFn(containerRef.current, {
-                sitekey: siteKey,
-                callback: (token: string) => {
-                    setError(null)
-                    setState("ready")
-                    onChange(token)
-                },
-                "expired-callback": () => {
-                    setError("reCAPTCHA expired. Please try again.")
-                    setState("error")
-                    onChange(null)
-                },
-                "error-callback": () => {
-                    setError("reCAPTCHA failed. Please retry.")
-                    setState("error")
-                    onChange(null)
-                },
-            })
-        }
+            const api = getApi()
+            api?.reset?.(widgetIdRef.current)
+            widgetIdRef.current = null
+            lastTokenRef.current = null
+        }, [getApi])
 
-        setState("loading")
-        ready ? ready(exec) : exec()
-    }, [onChange, siteKey])
+        const renderWidget = useCallback(() => {
+            if (!containerRef.current || !siteKey) {
+                return
+            }
 
-    useEffect(() => {
-        if (!siteKey) {
-            setError("reCAPTCHA site key is not configured.")
+            const g = window.grecaptcha
+            const api = g?.render ? g : g?.enterprise
+            const ready = api?.ready || g?.ready
+            const renderFn = api?.render
+
+            if (typeof renderFn !== "function") {
+                setError("Failed to initialise reCAPTCHA widget.")
+                setState("error")
+                onChange(null)
+                resolvePending(null, "Failed to initialise reCAPTCHA widget.")
+                return
+            }
+
+            const exec = () => {
+                if (!containerRef.current || widgetIdRef.current !== null) {
+                    return
+                }
+
+                const options: RecaptchaRenderOptions = {
+                    sitekey: siteKey,
+                    size: RECAPTCHA_SIZE,
+                    callback: (token: string) => {
+                        setError(null)
+                        setState("ready")
+                        lastTokenRef.current = token
+                        onChange(token)
+                        resolvePending(token)
+                    },
+                    "expired-callback": () => {
+                        setError("reCAPTCHA expired. Please try again.")
+                        setState("error")
+                        lastTokenRef.current = null
+                        onChange(null)
+                        resolvePending(null, "reCAPTCHA expired. Please try again.")
+                    },
+                    "error-callback": () => {
+                        setError("reCAPTCHA failed. Please retry.")
+                        setState("error")
+                        lastTokenRef.current = null
+                        onChange(null)
+                        resolvePending(null, "reCAPTCHA failed. Please retry.")
+                    },
+                }
+
+                if (RECAPTCHA_SIZE === "invisible" && RECAPTCHA_BADGE) {
+                    options.badge = RECAPTCHA_BADGE
+                }
+
+                widgetIdRef.current = renderFn(containerRef.current, options)
+            }
+
+            setState("loading")
+            ready ? ready(exec) : exec()
+        }, [onChange, resolvePending, siteKey])
+
+        useEffect(() => {
+            if (!siteKey) {
+                setError("reCAPTCHA site key is not configured.")
+                setState("error")
+                onChange(null)
+                resolvePending(null, "reCAPTCHA site key is not configured.")
+                return
+            }
+
+            if (scriptLoaded) {
+                renderWidget()
+            }
+        }, [onChange, renderWidget, resolvePending, scriptLoaded, siteKey])
+
+        useEffect(
+            () => () => {
+                resolvePending(null)
+                resetWidget()
+                onChange(null)
+            },
+            [onChange, resetWidget, resolvePending]
+        )
+
+        const handleScriptLoad = useCallback(() => {
+            if (!siteKey) {
+                return
+            }
+
+            renderWidget()
+        }, [renderWidget, siteKey])
+
+        const handleScriptError = useCallback(() => {
+            setError("Failed to load reCAPTCHA. Please reload the page.")
             setState("error")
             onChange(null)
-            return
-        }
+            resolvePending(null, "Failed to load reCAPTCHA. Please reload the page.")
+        }, [onChange, resolvePending])
 
-        if (scriptLoaded) {
-            renderWidget()
-        }
-    }, [onChange, renderWidget, scriptLoaded, siteKey])
+        const execute = useCallback(() => {
+            return new Promise<string>((resolve, reject) => {
+                if (!siteKey) {
+                    reject(new Error("reCAPTCHA site key is not configured."))
+                    return
+                }
 
-    useEffect(
-        () => () => {
+                const api = getApi()
+
+                if (RECAPTCHA_SIZE === "invisible") {
+                    if (typeof api?.execute !== "function" || widgetIdRef.current === null) {
+                        reject(new Error("reCAPTCHA is not ready yet."))
+                        return
+                    }
+
+                    pendingExecuteRef.current = { resolve, reject }
+                    const result = api.execute(widgetIdRef.current)
+
+                    // For implementations returning a token synchronously
+                    if (typeof result === "string") {
+                        lastTokenRef.current = result
+                        onChange(result)
+                        resolve(result)
+                        pendingExecuteRef.current = null
+                    }
+                    return
+                }
+
+                if (lastTokenRef.current) {
+                    resolve(lastTokenRef.current)
+                    return
+                }
+
+                reject(new Error("Please complete the reCAPTCHA challenge."))
+            })
+        }, [getApi, onChange, siteKey])
+
+        const reset = useCallback(() => {
+            resolvePending(null)
             resetWidget()
             onChange(null)
-        },
-        [onChange, resetWidget]
-    )
+        }, [onChange, resetWidget, resolvePending])
 
-    const handleScriptLoad = useCallback(() => {
-        if (!siteKey) {
-            return
-        }
+        useImperativeHandle(
+            ref,
+            () => ({
+                execute,
+                reset,
+            }),
+            [execute, reset]
+        )
 
-        renderWidget()
-    }, [renderWidget, siteKey])
+        return (
+            <>
+                <Script
+                    id={RECAPTCHA_SCRIPT_ID}
+                    src={RECAPTCHA_SCRIPT_SRC}
+                    strategy="lazyOnload"
+                    onLoad={handleScriptLoad}
+                    onError={handleScriptError}
+                />
+                <div ref={containerRef} aria-busy={state === "loading"} />
+                {error && (
+                    <p className="mt-3 text-center text-sm text-red-600 dark:text-red-400">{error}</p>
+                )}
+            </>
+        )
+    }
+)
 
-    const handleScriptError = useCallback(() => {
-        setError("Failed to load reCAPTCHA. Please reload the page.")
-        setState("error")
-        onChange(null)
-    }, [onChange])
+Recaptcha.displayName = "Recaptcha"
 
-    return (
-        <>
-            <Script
-                id={RECAPTCHA_SCRIPT_ID}
-                src={RECAPTCHA_SCRIPT_SRC}
-                strategy="lazyOnload"
-                onLoad={handleScriptLoad}
-                onError={handleScriptError}
-            />
-            <div ref={containerRef} aria-busy={state === "loading"} />
-            {error && (
-                <p className="mt-3 text-center text-sm text-red-600 dark:text-red-400">{error}</p>
-            )}
-        </>
-    )
-}
+export default Recaptcha


### PR DESCRIPTION
## Summary
- update the reCAPTCHA widget wrapper to expose execute/reset helpers and support invisible badge configuration
- adjust the contact form submission flow to execute invisible reCAPTCHA challenges and reset the widget on error or success

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d14f66cae0832d8c060d7b75423fa8