### PR TITLE
Fix export script for static output

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "export": "next export",
+    "export": "npm run build",
     "lint": "next lint",
     "postbuild": "next-sitemap",
     "test": "echo \"No tests configured\" && exit 0"


### PR DESCRIPTION
## Issue
[#54](https://github.com/hamasaki-code/My-portfolio/issues/54)


## 背景/目的

Next.js 14.2 では `next export` コマンドが廃止され、`next.config.js` に `output: 'export'` を設定したうえで `next build` を実行するワークフローに移行する必要があった。そのため、従来の `npm run export` が失敗していた。
 
## 実装内容
`package.json` の `export` スクリプトを `npm run build` に置き換え、静的ビルドとサイトマップ生成を自動で行うようにした。
 
## 方法
Next.js のビルドパイプラインは `postbuild` スクリプトとして `next-sitemap` を呼び出す構成になっているため、`npm run build` を実行するだけで `out/` 以下に静的ファイルとサイトマップが生成される。変更内容の適用後に `npm run export` を実行し、`out` ディレクトリに HTML・アセットが生成されることを確認した。
 
## 変更箇所
- `package.json` の `scripts.export` を `npm run build` に変更
 
## まとめ
`npm run export` で静的サイトを生成する運用を維持しつつ、Next.js 14 の新しい静的エクスポート方式へ移行できた。以降は `npm run export` を実行するだけで `out/` 配下に最新の静的アセットが出力される。

## Testing
- npm run export