### PR TITLE
Ensure gh-pages deploy has push permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main  # デプロイをトリガーするブランチ
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issue
[#56](https://github.com/hamasaki-code/My-portfolio/issues/56)

## Summary
- grant the deploy workflow write permissions so the GitHub Pages action can push to the gh-pages branch

## Testing
- npm run build
