### PR TITLE
Improve reCAPTCHA configuration handling

### DIFF
--- a/app/api/recaptcha-config/route.ts
+++ b/app/api/recaptcha-config/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server"
+
+import { createRecaptchaConfig } from "@/lib/recaptcha"
+
+export async function GET() {
+    const config = createRecaptchaConfig({
+        siteKey: process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY,
+        size: process.env.NEXT_PUBLIC_RECAPTCHA_SIZE,
+        badge: process.env.NEXT_PUBLIC_RECAPTCHA_BADGE,
+    })
+
+    return NextResponse.json(config, {
+        headers: {
+            "Cache-Control": "no-store",
+        },
+    })
+}

--- a/lib/recaptcha.ts
+++ b/lib/recaptcha.ts
@@ -1,0 +1,42 @@
+export type RecaptchaSize = "compact" | "normal" | "invisible"
+
+export type RecaptchaBadge = "bottomright" | "bottomleft" | "inline"
+
+export interface RecaptchaConfig {
+    siteKey: string | null
+    size: RecaptchaSize
+    badge?: RecaptchaBadge
+}
+
+export const sanitizeRecaptchaSiteKey = (value: unknown): string | null => {
+    if (typeof value !== "string") {
+        return null
+    }
+
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+}
+
+export const parseRecaptchaSize = (value: unknown): RecaptchaSize => {
+    return value === "compact" || value === "invisible" ? value : "normal"
+}
+
+export const parseRecaptchaBadge = (value: unknown): RecaptchaBadge | undefined => {
+    if (value === "bottomleft" || value === "inline") {
+        return value
+    }
+
+    return value === "bottomright" ? "bottomright" : undefined
+}
+
+export const createRecaptchaConfig = (input?: {
+    siteKey?: unknown
+    size?: unknown
+    badge?: unknown
+}): RecaptchaConfig => {
+    return {
+        siteKey: sanitizeRecaptchaSiteKey(input?.siteKey ?? null),
+        size: parseRecaptchaSize(input?.size),
+        badge: parseRecaptchaBadge(input?.badge),
+    }
+}


### PR DESCRIPTION
## Summary
- add a serverless endpoint that exposes the current reCAPTCHA configuration derived from environment variables
- reuse shared helpers to normalise the site key, size and badge and allow the client component to receive those values via props
- update the contact form to load the configuration at runtime, surface configuration errors to users, and block submission until the widget is ready

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d273f1d478832db5227d151ce788cd