### PR TITLE
Fix yup schema typings for contact API validation

### DIFF
--- a/types/yup.d.ts
+++ b/types/yup.d.ts
@@ -19,8 +19,17 @@ declare module "yup" {
         email(message?: string): this;
     }
 
-    export interface ObjectSchema<T extends Record<string, any>> extends AnySchema<T> {}
+    export type InferType<TSchema> = TSchema extends AnySchema<infer TValue> ? TValue : never;
 
-    export function object<T extends Record<string, any>>(shape: T): ObjectSchema<T>;
+    export type InferObjectShape<TShape extends Record<string, AnySchema<any>>> = {
+        [Key in keyof TShape]: InferType<TShape[Key]>;
+    };
+
+    export interface ObjectSchema<TShape extends Record<string, AnySchema<any>>>
+        extends AnySchema<InferObjectShape<TShape>> {}
+
+    export function object<TShape extends Record<string, AnySchema<any>>>(
+        shape: TShape
+    ): ObjectSchema<TShape>;
     export function string(): StringSchema;
 }


### PR DESCRIPTION
## Summary
- refine the custom yup TypeScript declarations so object schemas infer validated value types
- expose helper types that map object schema shapes to their resolved values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2a87c4968832db74d5c1bbdd2f01c