### PR TITLE
Update default social share image

### DIFF
--- a/app/components/SeoHead.tsx
+++ b/app/components/SeoHead.tsx
@@ -22,7 +22,7 @@ const SITE_URL = "https://taishi-hamasaki-portfolio.vercel.app";
 const DEFAULT_TITLE = "Taishi Hamasaki | Portfolio";
 const DEFAULT_DESCRIPTION =
   "Taishi Hamasaki's portfolio showcasing web development skills in React, Node.js, Flutter, and more. Explore projects and connect with me for collaboration.";
-const DEFAULT_IMAGE = "/profile.jpg";
+const DEFAULT_IMAGE = "/portfolio.png";
 const DEFAULT_THEME_COLOR = "#facc15";
 const DEFAULT_KEYWORDS = [
   "Taishi Hamasaki",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,7 +73,7 @@ export default function Home() {
           "TypeScript",
           "Tailwind CSS",
         ]}
-        ogImage="/profile.jpg"
+        ogImage="/portfolio.png"
         ogUrl={SITE_URL}
         themeColor="#facc15"
         twitterHandle="@OnTAumv5KAoVGN5"

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default function ProjectPage({ params }: ProjectPageProps) {
   const pageTitle = `${project.title} | Taishi Hamasaki`;
   const pageDescription =
     project.description[0] ?? "プロジェクトの詳細情報をご覧いただけます。";
-  const ogImage = project.image ?? "/profile.jpg";
+  const ogImage = project.image ?? "/portfolio.png";
   const keywords = Array.from(
     new Set(
       [


### PR DESCRIPTION
## Summary
- replace the default Open Graph image with the portfolio graphic so link previews no longer show the profile photo
- update the home and project pages to use the new social image when one is not specified

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d471102344832dbbb4410042e85a57