### PR TITLE
Improve image loading performance

### DIFF
--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -34,6 +34,7 @@ export default function About(): JSX.Element {
                 width={200}
                 height={200}
                 className="relative rounded-full border-4 border-yellow-200 object-cover shadow-[0_18px_45px_-28px_rgba(0,0,0,0.4)] dark:border-yellow-400"
+                sizes="200px"
                 priority
               />
             </div>

--- a/app/components/HistoryNavigationTracker.tsx
+++ b/app/components/HistoryNavigationTracker.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+
+export const HISTORY_RESTORE_SESSION_KEY = "portfolio-history-restore";
+
+export default function HistoryNavigationTracker() {
+  useEffect(() => {
+    const markHistoryRestore = () => {
+      try {
+        sessionStorage.setItem(HISTORY_RESTORE_SESSION_KEY, "true");
+      } catch {
+        // Ignore storage failures and keep browser navigation working normally.
+      }
+    };
+
+    window.addEventListener("popstate", markHistoryRestore);
+
+    return () => window.removeEventListener("popstate", markHistoryRestore);
+  }, []);
+
+  return null;
+}

--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -71,6 +71,7 @@ export default function Projects() {
             alt={`${project.title} のスクリーンショット`}
             width={isSvg ? 160 : 640}
             height={isSvg ? 160 : 360}
+            sizes="(min-width: 768px) 256px, calc(100vw - 96px)"
             className="h-full w-auto object-contain"
           />
         </div>

--- a/app/components/WorksBackLink.tsx
+++ b/app/components/WorksBackLink.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { HISTORY_RESTORE_SESSION_KEY } from "./HistoryNavigationTracker";
+
+type WorksBackLinkProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export default function WorksBackLink({
+  children,
+  className,
+}: WorksBackLinkProps) {
+  const handleClick = () => {
+    try {
+      sessionStorage.setItem(HISTORY_RESTORE_SESSION_KEY, "true");
+    } catch {
+      // Ignore storage failures and allow the navigation to proceed.
+    }
+  };
+
+  return (
+    <Link
+      href={{ pathname: "/", hash: "projects" }}
+      scroll={false}
+      className={className}
+      onClick={handleClick}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/react";
 import { ThemeProvider } from "./components/ThemeProvider";
+import HistoryNavigationTracker from "./components/HistoryNavigationTracker";
 import { SITE_URL } from "../lib/site";
 
 const geistSans = localFont({
@@ -68,6 +69,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <script dangerouslySetInnerHTML={{ __html: themeInitializer }} />
+        <HistoryNavigationTracker />
         <ThemeProvider>{children}</ThemeProvider>
         <SpeedInsights />
         <Analytics />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,18 +9,64 @@ import Skills from "./components/Skills";
 import Career from "./components/Career";
 import ContactForm from "./components/ContactForm";
 import LoadingScreen from "./components/LoadingScreen";
+import { HISTORY_RESTORE_SESSION_KEY } from "./components/HistoryNavigationTracker";
 import { SITE_URL } from "../lib/site";
 
+const LOADING_SCREEN_SESSION_KEY = "portfolio-loading-screen-shown";
+
+const shouldShowLoadingScreen = () => {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  const navigationEntry = performance.getEntriesByType("navigation")[0] as
+    | PerformanceNavigationTiming
+    | undefined;
+
+  if (navigationEntry?.type === "back_forward") {
+    return false;
+  }
+
+  try {
+    if (sessionStorage.getItem(HISTORY_RESTORE_SESSION_KEY) === "true") {
+      sessionStorage.removeItem(HISTORY_RESTORE_SESSION_KEY);
+      return false;
+    }
+  } catch {
+    return true;
+  }
+
+  if (navigationEntry?.type === "reload") {
+    return true;
+  }
+
+  try {
+    return sessionStorage.getItem(LOADING_SCREEN_SESSION_KEY) !== "true";
+  } catch {
+    return true;
+  }
+};
+
 export default function Home() {
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(shouldShowLoadingScreen);
 
   useEffect(() => {
+    if (!loading) {
+      return;
+    }
+
+    try {
+      sessionStorage.setItem(LOADING_SCREEN_SESSION_KEY, "true");
+    } catch {
+      // Ignore storage failures and keep the loading screen behavior best-effort.
+    }
+
     const timer = setTimeout(() => {
       setLoading(false);
     }, 1500);
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [loading]);
 
   useEffect(() => {
     if (loading) {

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { GiTennisCourt, GiCctvCamera } from "react-icons/gi";
 import { BsBadgeVr } from "react-icons/bs";
 import Header from "../../components/Header";
 import SeoHead from "../../components/SeoHead";
+import WorksBackLink from "../../components/WorksBackLink";
 import { projects } from "../../data/projects";
 import { toSiteUrl } from "../../../lib/site";
 
@@ -142,7 +143,9 @@ export default function ProjectPage({ params }: ProjectPageProps) {
             alt={`${project.title} のスクリーンショット`}
             width={imageWidth}
             height={imageHeight}
+            sizes="(min-width: 1024px) 45vw, calc(100vw - 48px)"
             className={imageClassName}
+            priority
           />
         </div>
       </div>
@@ -167,13 +170,11 @@ export default function ProjectPage({ params }: ProjectPageProps) {
       <div className="pointer-events-none absolute inset-y-0 right-[-20%] w-[60%] rounded-full bg-[radial-gradient(circle,_rgba(250,204,21,0.25)_0%,_rgba(255,255,255,0)_70%)] blur-3xl dark:bg-[radial-gradient(circle,_rgba(202,138,4,0.22)_0%,_rgba(0,0,0,0)_70%)]" />
       <main className="relative z-10 mx-auto flex max-w-6xl flex-col gap-16 px-6 pb-20 pt-32 transition-colors duration-500 lg:px-12">
         <div className="flex items-center justify-between gap-6">
-          <Link
-            href={{ pathname: "/", hash: "projects" }}
-            scroll={false}
+          <WorksBackLink
             className="inline-flex items-center gap-2 rounded-full border border-yellow-500/60 bg-yellow-400/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-yellow-700 transition hover:border-yellow-600 hover:bg-yellow-400/30 hover:text-black dark:border-yellow-300/40 dark:bg-yellow-400/10 dark:text-yellow-200 dark:hover:border-yellow-200/60 dark:hover:bg-yellow-400/15 dark:hover:text-white"
           >
             ← Works
-          </Link>
+          </WorksBackLink>
           {links && (links.site || links.github) && (
             <div className="flex flex-wrap items-center gap-3">
               {links.site && (

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  images: {
-    unoptimized: true, // Image Optimization API を無効化
-  },
-};
+const nextConfig = {};
 
 module.exports = nextConfig;


### PR DESCRIPTION
  ## Issue
https://github.com/hamasaki-code/My-portfolio/issues/81

  ## 目的

  Next.js の Image Optimization を有効化し、画像読み込みを改善する。
  ローディング画面は既存デザインと表示体験を残しつつ、初回アクセス・リロード時のみ表示し、戻る操作では表示しないようにする。

  ## 実装内容

  - Image Optimization を有効化
  - next/image の sizes 設定を追加
  - ファーストビュー相当のプロフィール画像は priority を維持
  - プロジェクト詳細のメイン画像に priority を追加
  - 初回アクセス・リロード時のみローディング画面を表示
  - ブラウザバック、スマホのスワイプ戻りではローディング画面を非表示
  - プロジェクト詳細ページの WORKS ボタンで戻る場合もローディング画面を非表示

  ## 実装方法

  next.config.js から images.unoptimized: true を削除し、Vercel 環境で Next.js の画像最適化が有効になるようにしました。

  ローディング制御は sessionStorage と Navigation Timing API を使って、初回アクセス・リロード・戻る操作を判定していま
  す。
  さらに、ブラウザバックやスマホスワイプを拾うために popstate を監視するコンポーネントを追加しました。
  WORKS ボタンは専用リンクコンポーネントに差し替え、クリック時にローディングスキップ用のフラグを保存するようにしています。

  ## 変更箇所

  - next.config.js
  - page.tsx
  - layout.tsx
  - About.tsx
  - Projects.tsx
  - HistoryNavigationTracker.tsx
  - WorksBackLink.tsx

  ## まとめ

  画像最適化を有効化し、主要画像に適切な sizes / priority を設定しました。
  ローディング画面は既存の見た目を残しつつ、初回アクセスとリロード時のみ表示されるように調整しています。ブラウザバック、スマホスワイプ戻り、WORKS ボタンで戻る場合はローディング画面を表示しないため、不要な待ち時間を減らせます。

  ## Testing

  - npm.cmd run build
  - 初期 HTML に Loading Portfolio が残っていることを確認
  - プロジェクト詳細画像が /_next/image?... 経由で最適化されていることを確認
  - 詳細ページのメイン画像に high priority が付いていることを確認
  - sitemap / robots の自動生成差分は今回対象外のため戻し済み
  - push 後の作業ツリーが clean であることを確認