### PR TITLE
Add footer copyright

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -6,16 +6,27 @@ export default function Footer() {
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
 
   useEffect(() => {
-    const now = new Date();
-    const nextYear = new Date(now.getFullYear() + 1, 0, 1);
-    const timeout = window.setTimeout(() => {
-      setCurrentYear(new Date().getFullYear());
-    }, nextYear.getTime() - now.getTime());
+    let timeoutId: number;
+
+    const scheduleYearRollover = () => {
+      const now = new Date();
+      const year = now.getFullYear();
+      const nextYear = new Date(year + 1, 0, 1);
+
+      setCurrentYear(year);
+
+      timeoutId = window.setTimeout(() => {
+        setCurrentYear(new Date().getFullYear());
+        scheduleYearRollover();
+      }, nextYear.getTime() - now.getTime());
+    };
+
+    scheduleYearRollover();
 
     return () => {
-      window.clearTimeout(timeout);
+      window.clearTimeout(timeoutId);
     };
-  }, [currentYear]);
+  }, []);
 
   return (
     <footer className="border-t border-black/10 bg-white/70 px-6 py-8 text-center text-sm text-gray-600 transition-colors dark:border-yellow-400/10 dark:bg-black/80 dark:text-yellow-100/70">

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,8 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
 export default function Footer() {
+  const [currentYear, setCurrentYear] = useState<number | null>(null);
+
+  useEffect(() => {
+    setCurrentYear(new Date().getFullYear());
+  }, []);
+
   return (
     <footer className="border-t border-black/10 bg-white/70 px-6 py-8 text-center text-sm text-gray-600 transition-colors dark:border-yellow-400/10 dark:bg-black/80 dark:text-yellow-100/70">
       <p>
-        &copy; {new Date().getFullYear()} Taishi Hamasaki. All rights reserved.
+        &copy;{" "}
+        <span className="inline-block min-w-10 text-center">
+          {currentYear ?? ""}
+        </span>{" "}
+        Taishi Hamasaki. All rights reserved.
       </p>
     </footer>
   );

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="border-t border-black/10 bg-white/70 px-6 py-8 text-center text-sm text-gray-600 transition-colors dark:border-yellow-400/10 dark:bg-black/80 dark:text-yellow-100/70">
+      <p>
+        &copy; {new Date().getFullYear()} Taishi Hamasaki. All rights reserved.
+      </p>
+    </footer>
+  );
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,31 +2,22 @@
 
 import { useEffect, useState } from "react";
 
-const MAX_TIMEOUT_DELAY = 2_147_483_647;
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 export default function Footer() {
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
 
   useEffect(() => {
-    let timeoutId: number | undefined;
-    let isActive = true;
+    let timeoutId: number;
 
     const scheduleYearRollover = () => {
-      if (!isActive) {
-        return;
-      }
-
       const now = new Date();
       const year = now.getFullYear();
       const nextYear = new Date(year + 1, 0, 1);
-      const delayUntilNextYear = nextYear.getTime() - now.getTime();
+      const msUntilNextYear = nextYear.getTime() - now.getTime();
+      const nextDelay = Math.max(1, Math.min(msUntilNextYear, MAX_TIMEOUT_MS));
 
-      setCurrentYear(year);
-
-      const nextDelay =
-        delayUntilNextYear > MAX_TIMEOUT_DELAY
-          ? MAX_TIMEOUT_DELAY
-          : delayUntilNextYear;
+      setCurrentYear((prevYear) => (prevYear === year ? prevYear : year));
 
       timeoutId = window.setTimeout(scheduleYearRollover, nextDelay);
     };
@@ -34,11 +25,7 @@ export default function Footer() {
     scheduleYearRollover();
 
     return () => {
-      isActive = false;
-
-      if (timeoutId) {
-        window.clearTimeout(timeoutId);
-      }
+      window.clearTimeout(timeoutId);
     };
   }, []);
 

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -3,21 +3,23 @@
 import { useEffect, useState } from "react";
 
 export default function Footer() {
-  const [currentYear, setCurrentYear] = useState<number | null>(null);
+  const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
 
   useEffect(() => {
-    setCurrentYear(new Date().getFullYear());
-  }, []);
+    const now = new Date();
+    const nextYear = new Date(now.getFullYear() + 1, 0, 1);
+    const timeout = window.setTimeout(() => {
+      setCurrentYear(new Date().getFullYear());
+    }, nextYear.getTime() - now.getTime());
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [currentYear]);
 
   return (
     <footer className="border-t border-black/10 bg-white/70 px-6 py-8 text-center text-sm text-gray-600 transition-colors dark:border-yellow-400/10 dark:bg-black/80 dark:text-yellow-100/70">
-      <p>
-        &copy;{" "}
-        <span className="inline-block min-w-10 text-center">
-          {currentYear ?? ""}
-        </span>{" "}
-        Taishi Hamasaki. All rights reserved.
-      </p>
+      <p>&copy; {currentYear} Taishi Hamasaki. All rights reserved.</p>
     </footer>
   );
 }

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,32 +2,43 @@
 
 import { useEffect, useState } from "react";
 
-const MAX_TIMEOUT_MS = 2_147_483_647;
+const MAX_TIMEOUT_DELAY = 2_147_483_647;
 
 export default function Footer() {
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
 
   useEffect(() => {
-    let timeoutId: number;
+    let timeoutId: number | undefined;
+    let isActive = true;
 
     const scheduleYearRollover = () => {
+      if (!isActive) {
+        return;
+      }
+
       const now = new Date();
       const year = now.getFullYear();
       const nextYear = new Date(year + 1, 0, 1);
-      const msUntilNextYear = nextYear.getTime() - now.getTime();
+      const delayUntilNextYear = nextYear.getTime() - now.getTime();
 
       setCurrentYear(year);
 
-      timeoutId = window.setTimeout(
-        scheduleYearRollover,
-        Math.min(msUntilNextYear, MAX_TIMEOUT_MS),
-      );
+      const nextDelay =
+        delayUntilNextYear > MAX_TIMEOUT_DELAY
+          ? MAX_TIMEOUT_DELAY
+          : delayUntilNextYear;
+
+      timeoutId = window.setTimeout(scheduleYearRollover, nextDelay);
     };
 
     scheduleYearRollover();
 
     return () => {
-      window.clearTimeout(timeoutId);
+      isActive = false;
+
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
     };
   }, []);
 

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,29 +2,41 @@
 
 import { useEffect, useState } from "react";
 
+const MAX_TIMEOUT_DELAY = 2_147_483_647;
+
 export default function Footer() {
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
 
   useEffect(() => {
-    let timeoutId: number;
+    let timeoutId: number | undefined;
+    let isActive = true;
 
     const scheduleYearRollover = () => {
+      if (!isActive) {
+        return;
+      }
+
       const now = new Date();
       const year = now.getFullYear();
       const nextYear = new Date(year + 1, 0, 1);
+      const delayUntilNextYear = nextYear.getTime() - now.getTime();
 
       setCurrentYear(year);
 
-      timeoutId = window.setTimeout(() => {
-        setCurrentYear(new Date().getFullYear());
-        scheduleYearRollover();
-      }, nextYear.getTime() - now.getTime());
+      timeoutId = window.setTimeout(
+        scheduleYearRollover,
+        Math.min(delayUntilNextYear, MAX_TIMEOUT_DELAY),
+      );
     };
 
     scheduleYearRollover();
 
     return () => {
-      window.clearTimeout(timeoutId);
+      isActive = false;
+
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
     };
   }, []);
 

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,41 +2,32 @@
 
 import { useEffect, useState } from "react";
 
-const MAX_TIMEOUT_DELAY = 2_147_483_647;
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 export default function Footer() {
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
 
   useEffect(() => {
-    let timeoutId: number | undefined;
-    let isActive = true;
+    let timeoutId: number;
 
     const scheduleYearRollover = () => {
-      if (!isActive) {
-        return;
-      }
-
       const now = new Date();
       const year = now.getFullYear();
       const nextYear = new Date(year + 1, 0, 1);
-      const delayUntilNextYear = nextYear.getTime() - now.getTime();
+      const msUntilNextYear = nextYear.getTime() - now.getTime();
 
       setCurrentYear(year);
 
       timeoutId = window.setTimeout(
         scheduleYearRollover,
-        Math.min(delayUntilNextYear, MAX_TIMEOUT_DELAY),
+        Math.min(msUntilNextYear, MAX_TIMEOUT_MS),
       );
     };
 
     scheduleYearRollover();
 
     return () => {
-      isActive = false;
-
-      if (timeoutId) {
-        window.clearTimeout(timeoutId);
-      }
+      window.clearTimeout(timeoutId);
     };
   }, []);
 

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 const MAX_TIMEOUT_DELAY = 2_147_483_647;
 
 export default function Footer() {
-  const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
+  const [currentYear, setCurrentYear] = useState<number | null>(null);
 
   useEffect(() => {
     let timeoutId: number | undefined;
@@ -46,7 +46,7 @@ export default function Footer() {
 
   return (
     <footer className="border-t border-black/10 bg-white/70 px-6 py-8 text-center text-sm text-gray-600 transition-colors dark:border-yellow-400/10 dark:bg-black/80 dark:text-yellow-100/70">
-      <p>&copy; {currentYear} Taishi Hamasaki. All rights reserved.</p>
+      <p suppressHydrationWarning>&copy; {currentYear ?? new Date().getUTCFullYear()} Taishi Hamasaki. All rights reserved.</p>
     </footer>
   );
 }

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,22 +2,33 @@
 
 import { useEffect, useState } from "react";
 
-const MAX_TIMEOUT_MS = 2_147_483_647;
+const MAX_TIMEOUT_DELAY = 2_147_483_647;
 
 export default function Footer() {
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
 
   useEffect(() => {
-    let timeoutId: number;
+    let timeoutId: number | undefined;
+    let isActive = true;
 
     const scheduleYearRollover = () => {
+      if (!isActive) {
+        return;
+      }
+
       const now = new Date();
       const year = now.getFullYear();
       const nextYear = new Date(year + 1, 0, 1);
-      const msUntilNextYear = nextYear.getTime() - now.getTime();
-      const nextDelay = Math.max(1, Math.min(msUntilNextYear, MAX_TIMEOUT_MS));
+      const delayUntilNextYear = nextYear.getTime() - now.getTime();
 
-      setCurrentYear((prevYear) => (prevYear === year ? prevYear : year));
+      setCurrentYear(year);
+
+      const nextDelay = Math.max(
+        1,
+        delayUntilNextYear > MAX_TIMEOUT_DELAY
+          ? MAX_TIMEOUT_DELAY
+          : delayUntilNextYear,
+      );
 
       timeoutId = window.setTimeout(scheduleYearRollover, nextDelay);
     };
@@ -25,7 +36,11 @@ export default function Footer() {
     scheduleYearRollover();
 
     return () => {
-      window.clearTimeout(timeoutId);
+      isActive = false;
+
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
     };
   }, []);
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/react";
 import { ThemeProvider } from "./components/ThemeProvider";
 import HistoryNavigationTracker from "./components/HistoryNavigationTracker";
+import Footer from "./components/Footer";
 import { SITE_URL } from "../lib/site";
 
 const geistSans = localFont({
@@ -70,7 +71,10 @@ export default function RootLayout({
       >
         <script dangerouslySetInnerHTML={{ __html: themeInitializer }} />
         <HistoryNavigationTracker />
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          {children}
+          <Footer />
+        </ThemeProvider>
         <SpeedInsights />
         <Analytics />
       </body>


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/My-portfolio/issues/87

  ## 目的

  サイト下部に一般的なコピーライト表記を追加し、公開用ポートフォリオとしての見た目と完成度を整える。

  ## 実装内容

  - Footer コンポーネントを新規作成
  - フッターに現在年を動的に表示するコピーライトを追加
  - 全ページ共通で表示されるようにレイアウトへ組み込み

  ## 実装方法

  - Footer.tsx を作成
  - new Date().getFullYear() を使って年を自動更新
  - layout.tsx で ThemeProvider 内に Footer を配置
  - light / dark 両テーマに馴染むよう Tailwind CSS でスタイル調整

  ## 変更箇所

  - Footer.tsx
  - layout.tsx

  ## まとめ

  フッター用コンポーネントを追加し、サイト全体の下部に © 2026 Taishi Hamasaki. All rights reserved. 形式のコピーライト表記が表示されるようにしました。年は現在年を自動取得するため、翌年以降も手動更新なしで表示が切り替わります。


  ## Testing

  - npm.cmd run build 実行
  - ビルド成功
  - 型チェック成功
  - 静的ページ生成成功