### PR TITLE
Exclude API routes from sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -3,6 +3,15 @@ module.exports = {
   siteUrl: 'https://taishi-hamasaki-portfolio.vercel.app',
   generateRobotsTxt: true,
   exclude: ['/api/*'],
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: '/api/',
+      },
+    ],
+  },
   // priorityやchangefreqなどのオプションも追加できます
   changefreq: 'daily',
   priority: 0.7,

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,7 @@
 # *
 User-agent: *
 Allow: /
+Disallow: /api/
 
 # Host
 Host: https://taishi-hamasaki-portfolio.vercel.app


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/My-portfolio/issues/90

  ## 目的

  API ルートを sitemap から除外し、検索エンジンに公開ページだけを適切に伝えるようにする。

  ## 実装内容

  next-sitemap の設定を確認し、/api/* が sitemap 生成対象から除外される状態を維持しました。
  あわせて robots.txt にも /api/ のクロール除外設定を追加し、sitemap と robots の方針を揃えました。

  ## 実装方法

  next-sitemap.config.js に robotsTxtOptions を追加し、User-agent: * に対して /api/ を Disallow する設定を追加しました。

  sitemap 生成後、API ルートが含まれていないこと、通常ページが残っていること、robots.txt に /api/ の除外設定が出力されていることを確認しました。

  ## 変更箇所

  - next-sitemap.config.js
  - robots.txt

  ## まとめ

  API ルートを検索エンジン向け sitemap から除外する設定を確認し、robots.txt 側にも /api/ の除外ルールを追加しました。これにより、公開ページは sitemap に残しつつ、API エンドポイントは検索対象として扱われにくい構成になりました。

  ## Testing

  npm.cmd run build

  追加確認:

  NO_API_IN_SITEMAP
  NORMAL_PAGE_PRESENT
  ROBOTS_API_DISALLOW_PRESENT
