### PR TITLE
Strengthen contact form security

### DIFF
--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -182,7 +182,11 @@ const getClientIp = (request: Request): string | null => {
     }
 
     const forwardedFor = request.headers.get("x-forwarded-for");
-    const forwardedIp = sanitizeIpAddress(forwardedFor?.split(",").at(-1));
+    const forwardedIp =
+        forwardedFor
+            ?.split(",")
+            .map((value) => sanitizeIpAddress(value))
+            .find((value): value is string => value !== null) ?? null;
 
     return (
         sanitizeIpAddress(request.headers.get("cf-connecting-ip")) ||

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -33,7 +33,7 @@ const MAX_CONTENT_LENGTH = 500;
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_CLEANUP_INTERVAL_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
-const RECAPTCHA_TIMEOUT_MS = 8000;
+const RECAPTCHA_TIMEOUT_MS = 5000;
 const rateLimitStore = new Map<string, number[]>();
 let lastRateLimitCleanupAt = 0;
 

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -235,12 +235,25 @@ const getRateLimitKey = (clientIp: string | null) => {
     return "anonymous:global";
 };
 
+const enforceRateLimitStoreCapacity = (now: number) => {
+    if (rateLimitStore.size <= RATE_LIMIT_MAX_BUCKETS) {
+        return;
+    }
+
+    cleanupStaleRateLimitBuckets(now, true);
+
+    if (rateLimitStore.size > RATE_LIMIT_MAX_BUCKETS) {
+        pruneRateLimitBucketsToMax();
+    }
+};
+
 const checkRateLimit = (key: string) => {
     const now = Date.now();
     cleanupStaleRateLimitBuckets(
         now,
         rateLimitStore.size >= RATE_LIMIT_MAX_BUCKETS
     );
+    enforceRateLimitStoreCapacity(now);
 
     const recentRequests = (rateLimitStore.get(key) ?? []).filter(
         (timestamp) => now - timestamp < RATE_LIMIT_WINDOW_MS
@@ -248,19 +261,13 @@ const checkRateLimit = (key: string) => {
 
     if (recentRequests.length >= RATE_LIMIT_MAX_REQUESTS) {
         rateLimitStore.set(key, recentRequests);
+        enforceRateLimitStoreCapacity(now);
         return false;
     }
 
     recentRequests.push(now);
     rateLimitStore.set(key, recentRequests);
-
-    if (rateLimitStore.size > RATE_LIMIT_MAX_BUCKETS) {
-        cleanupStaleRateLimitBuckets(now, true);
-
-        if (rateLimitStore.size > RATE_LIMIT_MAX_BUCKETS) {
-            pruneRateLimitBucketsToMax();
-        }
-    }
+    enforceRateLimitStoreCapacity(now);
 
     return true;
 };

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -193,14 +193,28 @@ const cleanupStaleRateLimitBuckets = (now: number) => {
     });
 };
 
-const getRateLimitKey = (clientIp: string | null, email: string) => {
+const normalizeRateLimitMetadata = (value: string | null) => {
+    return value?.trim().replace(/\s+/g, " ").slice(0, 200).toLowerCase() || "missing";
+};
+
+const getAnonymousRateLimitKey = (request: Request) => {
+    const metadata = [
+        normalizeRateLimitMetadata(request.headers.get("user-agent")),
+        normalizeRateLimitMetadata(request.headers.get("accept-language")),
+        normalizeRateLimitMetadata(request.headers.get("accept")),
+        normalizeRateLimitMetadata(request.headers.get("origin")),
+    ].join("|");
+    const metadataHash = createHash("sha256").update(metadata).digest("hex");
+
+    return `anonymous:${metadataHash}`;
+};
+
+const getRateLimitKey = (request: Request, clientIp: string | null) => {
     if (clientIp) {
         return `ip:${clientIp}`;
     }
 
-    const normalizedEmail = email.trim().toLowerCase();
-    const emailHash = createHash("sha256").update(normalizedEmail).digest("hex");
-    return `email:${emailHash}`;
+    return getAnonymousRateLimitKey(request);
 };
 
 const checkRateLimit = (key: string) => {
@@ -323,7 +337,7 @@ export async function POST(request: Request) {
         }
 
         const clientIp = getClientIp(request);
-        const rateLimitKey = getRateLimitKey(clientIp, validation.data.email);
+        const rateLimitKey = getRateLimitKey(request, clientIp);
 
         if (!checkRateLimit(rateLimitKey)) {
             return jsonError(

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -297,7 +297,9 @@ const verifyRecaptcha = async (
         RECAPTCHA_MIN_TIMEOUT_MS
     );
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    const timeoutId = setTimeout(() => {
+        controller.abort(new DOMException("Timed out", "TimeoutError"));
+    }, timeoutMs);
 
     try {
         const response = await fetch(

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -137,7 +137,7 @@ const validateContactRequest = (
     };
 };
 
-const getClientIp = (request: Request) => {
+const getClientIp = (request: Request): string | null => {
     const forwardedFor = request.headers.get("x-forwarded-for");
     const forwardedIp = forwardedFor?.split(",")[0]?.trim();
 
@@ -145,7 +145,7 @@ const getClientIp = (request: Request) => {
         forwardedIp ||
         request.headers.get("x-real-ip") ||
         request.headers.get("cf-connecting-ip") ||
-        "unknown"
+        null
     );
 };
 
@@ -167,7 +167,7 @@ const checkRateLimit = (key: string) => {
 
 const verifyRecaptcha = async (
     token: string,
-    clientIp: string
+    clientIp: string | null
 ): Promise<RecaptchaVerificationResult> => {
     const secret =
         process.env.RECAPTCHA_SECRET_KEY ?? process.env.RECAPTCHA_SECRET;
@@ -186,7 +186,7 @@ const verifyRecaptcha = async (
         response: token,
     });
 
-    if (clientIp !== "unknown") {
+    if (clientIp) {
         params.set("remoteip", clientIp);
     }
 
@@ -268,7 +268,7 @@ export async function POST(request: Request) {
 
         const clientIp = getClientIp(request);
 
-        if (!checkRateLimit(clientIp)) {
+        if (clientIp && !checkRateLimit(clientIp)) {
             return jsonError(
                 "送信回数が多すぎます。時間をおいて再度お試しください。",
                 429

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -33,6 +33,7 @@ const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_CLEANUP_INTERVAL_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
 const RECAPTCHA_TIMEOUT_MS = 5000;
+const RECAPTCHA_MIN_TIMEOUT_MS = 1000;
 const rateLimitStore = new Map<string, number[]>();
 let lastRateLimitCleanupAt = 0;
 
@@ -259,7 +260,7 @@ const verifyRecaptcha = async (
     const timeoutMs = parseMinimumNumber(
         process.env.RECAPTCHA_VERIFY_TIMEOUT_MS,
         RECAPTCHA_TIMEOUT_MS,
-        1000
+        RECAPTCHA_MIN_TIMEOUT_MS
     );
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -182,11 +182,7 @@ const getClientIp = (request: Request): string | null => {
     }
 
     const forwardedFor = request.headers.get("x-forwarded-for");
-    const forwardedIp =
-        forwardedFor
-            ?.split(",")
-            .map((value) => sanitizeIpAddress(value))
-            .find((value): value is string => value !== null) ?? null;
+    const forwardedIp = sanitizeIpAddress(forwardedFor?.split(",")[0]);
 
     return (
         sanitizeIpAddress(request.headers.get("cf-connecting-ip")) ||
@@ -260,9 +256,12 @@ const checkRateLimit = (key: string) => {
 
     if (rateLimitStore.size > RATE_LIMIT_MAX_BUCKETS) {
         cleanupStaleRateLimitBuckets(now, true);
+
+        if (rateLimitStore.size > RATE_LIMIT_MAX_BUCKETS) {
+            pruneRateLimitBucketsToMax();
+        }
     }
 
-    pruneRateLimitBucketsToMax();
     return true;
 };
 

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -33,6 +33,7 @@ const MAX_CONTENT_LENGTH = 500;
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_CLEANUP_INTERVAL_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
+const RECAPTCHA_TIMEOUT_MS = 8000;
 const rateLimitStore = new Map<string, number[]>();
 let lastRateLimitCleanupAt = 0;
 
@@ -62,6 +63,14 @@ const parseNumber = (value: string | undefined, fallback: number) => {
     return Number.isFinite(parsed) ? parsed : fallback;
 };
 
+const parseMinimumNumber = (
+    value: string | undefined,
+    fallback: number,
+    minimum: number
+) => {
+    return Math.max(parseNumber(value, fallback), minimum);
+};
+
 const isSelfSignedCertificateError = (error: unknown) => {
     if (!(error instanceof Error)) {
         return false;
@@ -73,6 +82,10 @@ const isSelfSignedCertificateError = (error: unknown) => {
         message.includes("self-signed certificate") ||
         message.includes("unable to verify the first certificate")
     );
+};
+
+const isAbortError = (error: unknown) => {
+    return error instanceof DOMException && error.name === "AbortError";
 };
 
 const jsonError = (
@@ -260,6 +273,14 @@ const verifyRecaptcha = async (
         params.set("remoteip", clientIp);
     }
 
+    const timeoutMs = parseMinimumNumber(
+        process.env.RECAPTCHA_VERIFY_TIMEOUT_MS,
+        RECAPTCHA_TIMEOUT_MS,
+        1000
+    );
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
     try {
         const response = await fetch(
             "https://www.google.com/recaptcha/api/siteverify",
@@ -269,6 +290,7 @@ const verifyRecaptcha = async (
                     "Content-Type": "application/x-www-form-urlencoded",
                 },
                 body: params,
+                signal: controller.signal,
             }
         );
 
@@ -297,12 +319,23 @@ const verifyRecaptcha = async (
 
         return { ok: true };
     } catch (error) {
+        if (isAbortError(error)) {
+            console.error("reCAPTCHA verification timed out.", { timeoutMs });
+            return {
+                ok: false,
+                status: 502,
+                error: "reCAPTCHA認証がタイムアウトしました。時間をおいて再度お試しください。",
+            };
+        }
+
         console.error("reCAPTCHA verification error.", error);
         return {
             ok: false,
             status: 502,
             error: "reCAPTCHA認証を確認できませんでした。時間をおいて再度お試しください。",
         };
+    } finally {
+        clearTimeout(timeoutId);
     }
 };
 

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -191,8 +191,8 @@ const getClientIp = (request: Request): string | null => {
     );
 };
 
-const cleanupStaleRateLimitBuckets = (now: number) => {
-    if (now - lastRateLimitCleanupAt < RATE_LIMIT_CLEANUP_INTERVAL_MS) {
+const cleanupStaleRateLimitBuckets = (now: number, force = false) => {
+    if (!force && now - lastRateLimitCleanupAt < RATE_LIMIT_CLEANUP_INTERVAL_MS) {
         return;
     }
 
@@ -237,7 +237,10 @@ const getRateLimitKey = (clientIp: string | null) => {
 
 const checkRateLimit = (key: string) => {
     const now = Date.now();
-    cleanupStaleRateLimitBuckets(now);
+    cleanupStaleRateLimitBuckets(
+        now,
+        rateLimitStore.size >= RATE_LIMIT_MAX_BUCKETS
+    );
 
     const recentRequests = (rateLimitStore.get(key) ?? []).filter(
         (timestamp) => now - timestamp < RATE_LIMIT_WINDOW_MS

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -1,5 +1,4 @@
 import nodemailer from "nodemailer";
-import { createHash } from "node:crypto";
 import { isIP } from "node:net";
 import { NextResponse } from "next/server";
 
@@ -206,28 +205,12 @@ const cleanupStaleRateLimitBuckets = (now: number) => {
     });
 };
 
-const normalizeRateLimitMetadata = (value: string | null) => {
-    return value?.trim().replace(/\s+/g, " ").slice(0, 200).toLowerCase() || "missing";
-};
-
-const getAnonymousRateLimitKey = (request: Request) => {
-    const metadata = [
-        normalizeRateLimitMetadata(request.headers.get("user-agent")),
-        normalizeRateLimitMetadata(request.headers.get("accept-language")),
-        normalizeRateLimitMetadata(request.headers.get("accept")),
-        normalizeRateLimitMetadata(request.headers.get("origin")),
-    ].join("|");
-    const metadataHash = createHash("sha256").update(metadata).digest("hex");
-
-    return `anonymous:${metadataHash}`;
-};
-
-const getRateLimitKey = (request: Request, clientIp: string | null) => {
+const getRateLimitKey = (clientIp: string | null) => {
     if (clientIp) {
         return `ip:${clientIp}`;
     }
 
-    return getAnonymousRateLimitKey(request);
+    return "anonymous:global";
 };
 
 const checkRateLimit = (key: string) => {
@@ -370,7 +353,7 @@ export async function POST(request: Request) {
         }
 
         const clientIp = getClientIp(request);
-        const rateLimitKey = getRateLimitKey(request, clientIp);
+        const rateLimitKey = getRateLimitKey(clientIp);
 
         if (!checkRateLimit(rateLimitKey)) {
             return jsonError(

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -32,6 +32,7 @@ const MAX_CONTENT_LENGTH = 500;
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_CLEANUP_INTERVAL_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
+const RATE_LIMIT_MAX_BUCKETS = 5000;
 const RECAPTCHA_TIMEOUT_MS = 5000;
 const RECAPTCHA_MIN_TIMEOUT_MS = 1000;
 const rateLimitStore = new Map<string, number[]>();
@@ -84,8 +85,12 @@ const isSelfSignedCertificateError = (error: unknown) => {
     );
 };
 
-const isAbortError = (error: unknown) => {
-    return error instanceof DOMException && error.name === "AbortError";
+const isTimeoutError = (error: unknown) => {
+    if (!(error instanceof Error || error instanceof DOMException)) {
+        return false;
+    }
+
+    return error.name === "AbortError" || error.name === "TimeoutError";
 };
 
 const jsonError = (
@@ -206,6 +211,18 @@ const cleanupStaleRateLimitBuckets = (now: number) => {
     });
 };
 
+const pruneRateLimitBucketsToMax = () => {
+    while (rateLimitStore.size > RATE_LIMIT_MAX_BUCKETS) {
+        const oldestKey = rateLimitStore.keys().next().value;
+
+        if (typeof oldestKey !== "string") {
+            return;
+        }
+
+        rateLimitStore.delete(oldestKey);
+    }
+};
+
 const getRateLimitKey = (clientIp: string | null) => {
     if (clientIp) {
         return `ip:${clientIp}`;
@@ -229,6 +246,7 @@ const checkRateLimit = (key: string) => {
 
     recentRequests.push(now);
     rateLimitStore.set(key, recentRequests);
+    pruneRateLimitBucketsToMax();
     return true;
 };
 
@@ -262,8 +280,6 @@ const verifyRecaptcha = async (
         RECAPTCHA_TIMEOUT_MS,
         RECAPTCHA_MIN_TIMEOUT_MS
     );
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
         const response = await fetch(
@@ -274,7 +290,7 @@ const verifyRecaptcha = async (
                     "Content-Type": "application/x-www-form-urlencoded",
                 },
                 body: params,
-                signal: controller.signal,
+                signal: AbortSignal.timeout(timeoutMs),
             }
         );
 
@@ -303,7 +319,7 @@ const verifyRecaptcha = async (
 
         return { ok: true };
     } catch (error) {
-        if (isAbortError(error)) {
+        if (isTimeoutError(error)) {
             console.error("reCAPTCHA verification timed out.", { timeoutMs });
             return {
                 ok: false,
@@ -318,8 +334,6 @@ const verifyRecaptcha = async (
             status: 502,
             error: "reCAPTCHA認証を確認できませんでした。時間をおいて再度お試しください。",
         };
-    } finally {
-        clearTimeout(timeoutId);
     }
 };
 

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -1,4 +1,5 @@
 import nodemailer from "nodemailer";
+import { isIP } from "node:net";
 import { NextResponse } from "next/server";
 
 type ContactRequestBody = {
@@ -137,15 +138,35 @@ const validateContactRequest = (
     };
 };
 
+const shouldTrustForwardedIpHeaders = () => {
+    return parseBoolean(
+        process.env.TRUST_FORWARDED_IP_HEADERS,
+        process.env.VERCEL === "1"
+    );
+};
+
+const sanitizeIpAddress = (value: string | null | undefined) => {
+    const candidate = value?.trim();
+
+    if (!candidate || !isIP(candidate)) {
+        return null;
+    }
+
+    return candidate;
+};
+
 const getClientIp = (request: Request): string | null => {
+    if (!shouldTrustForwardedIpHeaders()) {
+        return null;
+    }
+
     const forwardedFor = request.headers.get("x-forwarded-for");
-    const forwardedIp = forwardedFor?.split(",")[0]?.trim();
+    const forwardedIp = sanitizeIpAddress(forwardedFor?.split(",")[0]);
 
     return (
-        forwardedIp ||
-        request.headers.get("x-real-ip") ||
-        request.headers.get("cf-connecting-ip") ||
-        null
+        sanitizeIpAddress(request.headers.get("cf-connecting-ip")) ||
+        sanitizeIpAddress(request.headers.get("x-real-ip")) ||
+        forwardedIp
     );
 };
 

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -299,6 +299,7 @@ const verifyRecaptcha = async (
     const timeoutId = setTimeout(() => {
         controller.abort(new DOMException("Timed out", "TimeoutError"));
     }, timeoutMs);
+    timeoutId.unref?.();
 
     try {
         const response = await fetch(

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -284,6 +284,8 @@ const verifyRecaptcha = async (
         RECAPTCHA_TIMEOUT_MS,
         RECAPTCHA_MIN_TIMEOUT_MS
     );
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
         const response = await fetch(
@@ -294,7 +296,7 @@ const verifyRecaptcha = async (
                     "Content-Type": "application/x-www-form-urlencoded",
                 },
                 body: params,
-                signal: AbortSignal.timeout(timeoutMs),
+                signal: controller.signal,
             }
         );
 
@@ -338,6 +340,8 @@ const verifyRecaptcha = async (
             status: 502,
             error: "reCAPTCHA認証を確認できませんでした。時間をおいて再度お試しください。",
         };
+    } finally {
+        clearTimeout(timeoutId);
     }
 };
 

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -1,4 +1,5 @@
 import nodemailer from "nodemailer";
+import { createHash } from "node:crypto";
 import { isIP } from "node:net";
 import { NextResponse } from "next/server";
 
@@ -30,8 +31,10 @@ const MAX_NAME_LENGTH = 100;
 const MAX_EMAIL_LENGTH = 254;
 const MAX_CONTENT_LENGTH = 500;
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const RATE_LIMIT_CLEANUP_INTERVAL_MS = 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
 const rateLimitStore = new Map<string, number[]>();
+let lastRateLimitCleanupAt = 0;
 
 const parseBoolean = (value: string | undefined, fallback: boolean) => {
     if (value === undefined) {
@@ -170,8 +173,40 @@ const getClientIp = (request: Request): string | null => {
     );
 };
 
+const cleanupStaleRateLimitBuckets = (now: number) => {
+    if (now - lastRateLimitCleanupAt < RATE_LIMIT_CLEANUP_INTERVAL_MS) {
+        return;
+    }
+
+    lastRateLimitCleanupAt = now;
+
+    rateLimitStore.forEach((timestamps, key) => {
+        const recentRequests = timestamps.filter(
+            (timestamp) => now - timestamp < RATE_LIMIT_WINDOW_MS
+        );
+
+        if (recentRequests.length === 0) {
+            rateLimitStore.delete(key);
+        } else if (recentRequests.length !== timestamps.length) {
+            rateLimitStore.set(key, recentRequests);
+        }
+    });
+};
+
+const getRateLimitKey = (clientIp: string | null, email: string) => {
+    if (clientIp) {
+        return `ip:${clientIp}`;
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+    const emailHash = createHash("sha256").update(normalizedEmail).digest("hex");
+    return `email:${emailHash}`;
+};
+
 const checkRateLimit = (key: string) => {
     const now = Date.now();
+    cleanupStaleRateLimitBuckets(now);
+
     const recentRequests = (rateLimitStore.get(key) ?? []).filter(
         (timestamp) => now - timestamp < RATE_LIMIT_WINDOW_MS
     );
@@ -288,8 +323,9 @@ export async function POST(request: Request) {
         }
 
         const clientIp = getClientIp(request);
+        const rateLimitKey = getRateLimitKey(clientIp, validation.data.email);
 
-        if (clientIp && !checkRateLimit(clientIp)) {
+        if (!checkRateLimit(rateLimitKey)) {
             return jsonError(
                 "送信回数が多すぎます。時間をおいて再度お試しください。",
                 429

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -182,7 +182,7 @@ const getClientIp = (request: Request): string | null => {
     }
 
     const forwardedFor = request.headers.get("x-forwarded-for");
-    const forwardedIp = sanitizeIpAddress(forwardedFor?.split(",")[0]);
+    const forwardedIp = sanitizeIpAddress(forwardedFor?.split(",").at(-1));
 
     return (
         sanitizeIpAddress(request.headers.get("cf-connecting-ip")) ||
@@ -212,15 +212,19 @@ const cleanupStaleRateLimitBuckets = (now: number) => {
 };
 
 const pruneRateLimitBucketsToMax = () => {
-    while (rateLimitStore.size > RATE_LIMIT_MAX_BUCKETS) {
-        const oldestKey = rateLimitStore.keys().next().value;
-
-        if (typeof oldestKey !== "string") {
-            return;
-        }
-
-        rateLimitStore.delete(oldestKey);
+    if (rateLimitStore.size <= RATE_LIMIT_MAX_BUCKETS) {
+        return;
     }
+
+    const overflowCount = rateLimitStore.size - RATE_LIMIT_MAX_BUCKETS;
+    const oldestBuckets = Array.from(rateLimitStore, ([key, timestamps]) => ({
+        key,
+        oldestTimestamp: timestamps[0] ?? 0,
+    })).sort((left, right) => left.oldestTimestamp - right.oldestTimestamp);
+
+    oldestBuckets.slice(0, overflowCount).forEach(({ key }) => {
+        rateLimitStore.delete(key);
+    });
 };
 
 const getRateLimitKey = (clientIp: string | null) => {

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -2,10 +2,35 @@ import nodemailer from "nodemailer";
 import { NextResponse } from "next/server";
 
 type ContactRequestBody = {
-    name?: string;
-    email?: string;
-    content?: string;
+    name?: unknown;
+    email?: unknown;
+    content?: unknown;
+    recaptchaToken?: unknown;
 };
+
+type ValidatedContactRequest = {
+    name: string;
+    email: string;
+    content: string;
+    recaptchaToken: string;
+};
+
+type RecaptchaVerifyResponse = {
+    success?: boolean;
+    "error-codes"?: string[];
+};
+
+type RecaptchaVerificationResult =
+    | { ok: true }
+    | { ok: false; status: number; error: string };
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_NAME_LENGTH = 100;
+const MAX_EMAIL_LENGTH = 254;
+const MAX_CONTENT_LENGTH = 500;
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+const rateLimitStore = new Map<string, number[]>();
 
 const parseBoolean = (value: string | undefined, fallback: boolean) => {
     if (value === undefined) {
@@ -46,9 +71,218 @@ const isSelfSignedCertificateError = (error: unknown) => {
     );
 };
 
+const jsonError = (
+    error: string,
+    status: number,
+    fields?: Record<string, string>
+) => {
+    return NextResponse.json(
+        {
+            error,
+            ...(fields ? { fields } : {}),
+        },
+        { status }
+    );
+};
+
+const normalizeString = (value: unknown) => {
+    return typeof value === "string" ? value.trim() : "";
+};
+
+const validateContactRequest = (
+    body: ContactRequestBody
+):
+    | { ok: true; data: ValidatedContactRequest }
+    | { ok: false; fields: Record<string, string> } => {
+    const name = normalizeString(body.name);
+    const email = normalizeString(body.email);
+    const content = normalizeString(body.content);
+    const recaptchaToken = normalizeString(body.recaptchaToken);
+    const fields: Record<string, string> = {};
+
+    if (!name) {
+        fields.name = "お名前を入力してください。";
+    } else if (name.length > MAX_NAME_LENGTH) {
+        fields.name = `お名前は${MAX_NAME_LENGTH}文字以内で入力してください。`;
+    }
+
+    if (!email) {
+        fields.email = "メールアドレスを入力してください。";
+    } else if (email.length > MAX_EMAIL_LENGTH || !EMAIL_PATTERN.test(email)) {
+        fields.email = "有効なメールアドレスを入力してください。";
+    }
+
+    if (!content) {
+        fields.content = "お問い合わせ内容を入力してください。";
+    } else if (content.length > MAX_CONTENT_LENGTH) {
+        fields.content = `お問い合わせ内容は${MAX_CONTENT_LENGTH}文字以内で入力してください。`;
+    }
+
+    if (!recaptchaToken) {
+        fields.recaptchaToken = "reCAPTCHA認証を完了してください。";
+    }
+
+    if (Object.keys(fields).length > 0) {
+        return { ok: false, fields };
+    }
+
+    return {
+        ok: true,
+        data: {
+            name,
+            email,
+            content,
+            recaptchaToken,
+        },
+    };
+};
+
+const getClientIp = (request: Request) => {
+    const forwardedFor = request.headers.get("x-forwarded-for");
+    const forwardedIp = forwardedFor?.split(",")[0]?.trim();
+
+    return (
+        forwardedIp ||
+        request.headers.get("x-real-ip") ||
+        request.headers.get("cf-connecting-ip") ||
+        "unknown"
+    );
+};
+
+const checkRateLimit = (key: string) => {
+    const now = Date.now();
+    const recentRequests = (rateLimitStore.get(key) ?? []).filter(
+        (timestamp) => now - timestamp < RATE_LIMIT_WINDOW_MS
+    );
+
+    if (recentRequests.length >= RATE_LIMIT_MAX_REQUESTS) {
+        rateLimitStore.set(key, recentRequests);
+        return false;
+    }
+
+    recentRequests.push(now);
+    rateLimitStore.set(key, recentRequests);
+    return true;
+};
+
+const verifyRecaptcha = async (
+    token: string,
+    clientIp: string
+): Promise<RecaptchaVerificationResult> => {
+    const secret =
+        process.env.RECAPTCHA_SECRET_KEY ?? process.env.RECAPTCHA_SECRET;
+
+    if (!secret) {
+        console.error("Missing reCAPTCHA secret key.");
+        return {
+            ok: false,
+            status: 500,
+            error: "reCAPTCHA設定が不足しています。",
+        };
+    }
+
+    const params = new URLSearchParams({
+        secret,
+        response: token,
+    });
+
+    if (clientIp !== "unknown") {
+        params.set("remoteip", clientIp);
+    }
+
+    try {
+        const response = await fetch(
+            "https://www.google.com/recaptcha/api/siteverify",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                body: params,
+            }
+        );
+
+        if (!response.ok) {
+            console.error("reCAPTCHA verification request failed.", response.status);
+            return {
+                ok: false,
+                status: 502,
+                error: "reCAPTCHA認証を確認できませんでした。時間をおいて再度お試しください。",
+            };
+        }
+
+        const result = (await response.json()) as RecaptchaVerifyResponse;
+
+        if (!result.success) {
+            console.warn(
+                "reCAPTCHA verification failed.",
+                result["error-codes"] ?? []
+            );
+            return {
+                ok: false,
+                status: 403,
+                error: "reCAPTCHA認証に失敗しました。再度お試しください。",
+            };
+        }
+
+        return { ok: true };
+    } catch (error) {
+        console.error("reCAPTCHA verification error.", error);
+        return {
+            ok: false,
+            status: 502,
+            error: "reCAPTCHA認証を確認できませんでした。時間をおいて再度お試しください。",
+        };
+    }
+};
+
 export async function POST(request: Request) {
     try {
-        const { name, email, content }: ContactRequestBody = await request.json();
+        let body: ContactRequestBody;
+
+        try {
+            const parsedBody = await request.json();
+
+            if (
+                !parsedBody ||
+                typeof parsedBody !== "object" ||
+                Array.isArray(parsedBody)
+            ) {
+                return jsonError("リクエストの形式が正しくありません。", 400);
+            }
+
+            body = parsedBody as ContactRequestBody;
+        } catch {
+            return jsonError("リクエストの形式が正しくありません。", 400);
+        }
+
+        const validation = validateContactRequest(body);
+
+        if (!validation.ok) {
+            return jsonError(
+                "入力内容を確認してください。",
+                400,
+                validation.fields
+            );
+        }
+
+        const clientIp = getClientIp(request);
+
+        if (!checkRateLimit(clientIp)) {
+            return jsonError(
+                "送信回数が多すぎます。時間をおいて再度お試しください。",
+                429
+            );
+        }
+
+        const recaptcha = await verifyRecaptcha(
+            validation.data.recaptchaToken,
+            clientIp
+        );
+
+        if (!recaptcha.ok) {
+            return jsonError(recaptcha.error, recaptcha.status);
+        }
 
         const smtpUser =
             process.env.MAIL_ACCOUNT ??
@@ -64,14 +298,18 @@ export async function POST(request: Request) {
                 "Missing SMTP credentials. Please configure MAIL_ACCOUNT/MAIL_PASSWORD, AUTH_USER/AUTH_PASS, or EMAIL_USER/EMAIL_PASS."
             );
 
-            return NextResponse.json(
-                { error: "メール設定が行われていないため送信に失敗しました。管理者にお問い合わせください。" },
-                { status: 500 }
+            return jsonError(
+                "メール設定が行われていないため送信に失敗しました。管理者にお問い合わせください。",
+                500
             );
         }
 
         const fromAddress = process.env.MAIL_FROM ?? smtpUser;
-        const ownerAddress = process.env.MAIL_TO ?? process.env.CONTACT_TO ?? smtpUser;
+        const ownerAddress =
+            process.env.MAIL_TO ??
+            process.env.CONTACT_TO ??
+            process.env.RECIPIENT_EMAIL ??
+            smtpUser;
 
         const host = process.env.SMTP_HOST ?? process.env.MAIL_HOST ?? "smtp.gmail.com";
         const port = parseNumber(process.env.SMTP_PORT ?? process.env.MAIL_PORT, 465);
@@ -112,25 +350,20 @@ export async function POST(request: Request) {
                 },
             });
 
-        const senderName = name?.trim() || "匿名";
-        const senderEmail = email?.trim();
-        const message = content?.trim() || "(本文なし)";
         const mailSubject = "【Portfolio】お問い合わせフォームに新着メッセージ";
 
         const ownerMail = {
             from: fromAddress,
             to: ownerAddress,
-            replyTo: senderEmail,
+            replyTo: validation.data.email,
             subject: mailSubject,
             text: [
-                `お名前: ${senderName}`,
-                senderEmail ? `メールアドレス: ${senderEmail}` : null,
+                `お名前: ${validation.data.name}`,
+                `メールアドレス: ${validation.data.email}`,
                 "",
                 "お問い合わせ内容:",
-                message,
-            ]
-                .filter((line): line is string => Boolean(line))
-                .join("\n"),
+                validation.data.content,
+            ].join("\n"),
         } satisfies nodemailer.SendMailOptions;
 
         let transporter = createTransporter();
@@ -158,16 +391,13 @@ export async function POST(request: Request) {
         return NextResponse.json({ message: "メールが送信されました。" });
     } catch (error) {
         console.error(error);
-        return NextResponse.json(
-            { error: "メールの送信中にエラーが発生しました。" },
-            { status: 500 }
+        return jsonError(
+            "メールの送信中にエラーが発生しました。",
+            500
         );
     }
 }
 
 export function GET() {
-    return NextResponse.json(
-        { error: "POSTメソッドを使用してください。" },
-        { status: 405 }
-    );
+    return jsonError("POSTメソッドを使用してください。", 405);
 }

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -257,6 +257,11 @@ const checkRateLimit = (key: string) => {
 
     recentRequests.push(now);
     rateLimitStore.set(key, recentRequests);
+
+    if (rateLimitStore.size > RATE_LIMIT_MAX_BUCKETS) {
+        cleanupStaleRateLimitBuckets(now, true);
+    }
+
     pruneRateLimitBucketsToMax();
     return true;
 };

--- a/app/api/sendmail/route.ts
+++ b/app/api/sendmail/route.ts
@@ -166,8 +166,26 @@ const shouldTrustForwardedIpHeaders = () => {
     );
 };
 
-const sanitizeIpAddress = (value: string | null | undefined) => {
+const normalizeIpAddressCandidate = (value: string | null | undefined) => {
     const candidate = value?.trim();
+
+    if (!candidate) {
+        return null;
+    }
+
+    const bracketedAddress = candidate.match(/^\[([^\]]+)\](?::\d+)?$/)?.[1];
+
+    if (bracketedAddress) {
+        return bracketedAddress;
+    }
+
+    const ipv4WithPort = candidate.match(/^(\d{1,3}(?:\.\d{1,3}){3}):\d+$/)?.[1];
+
+    return ipv4WithPort ?? candidate;
+};
+
+const sanitizeIpAddress = (value: string | null | undefined) => {
+    const candidate = normalizeIpAddressCandidate(value);
 
     if (!candidate || !isIP(candidate)) {
         return null;

--- a/app/components/ContactForm.tsx
+++ b/app/components/ContactForm.tsx
@@ -17,6 +17,8 @@ type ContactFieldErrors = Partial<
     Record<keyof ContactFormValues | "recaptcha", string>
 >;
 
+const ignoreRecaptchaChange = () => undefined;
+
 export default function ContactForm() {
     const [form, setForm] = useState(DEFAULT_FORM);
     const [status, setStatus] = useState<"idle" | "sending" | "success" | "error">("idle");
@@ -258,7 +260,7 @@ export default function ContactForm() {
 
                     <Recaptcha
                         ref={recaptchaRef}
-                        onChange={() => undefined}
+                        onChange={ignoreRecaptchaChange}
                     />
                     {fieldErrors.recaptcha && (
                         <p className="text-center text-sm text-red-600 dark:text-red-400">

--- a/app/components/ContactForm.tsx
+++ b/app/components/ContactForm.tsx
@@ -5,6 +5,7 @@ import type { ChangeEvent, FormEvent } from "react";
 import { FiUser, FiMail, FiMessageSquare, FiSend, FiLoader, FiCheck, FiGithub } from "react-icons/fi";
 import { RiTwitterXLine, RiAccountCircleLine } from "react-icons/ri";
 import { SiWantedly, SiLinkedin } from "react-icons/si";
+import Recaptcha, { type RecaptchaHandle } from "./Recaptcha";
 
 const DEFAULT_FORM = {
     name: "",
@@ -12,12 +13,17 @@ const DEFAULT_FORM = {
     message: "",
 };
 type ContactFormValues = typeof DEFAULT_FORM;
+type ContactFieldErrors = Partial<
+    Record<keyof ContactFormValues | "recaptcha", string>
+>;
 
 export default function ContactForm() {
     const [form, setForm] = useState(DEFAULT_FORM);
     const [status, setStatus] = useState<"idle" | "sending" | "success" | "error">("idle");
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<ContactFieldErrors>({});
     const modalRef = useRef<HTMLDivElement>(null);
+    const recaptchaRef = useRef<RecaptchaHandle>(null);
 
     useEffect(() => {
         if (status === "success" || status === "error") {
@@ -37,6 +43,15 @@ export default function ContactForm() {
                 ...prev,
                 [field]: value,
             }));
+            setFieldErrors((prev) => {
+                if (!prev[field]) {
+                    return prev;
+                }
+
+                const next = { ...prev };
+                delete next[field];
+                return next;
+            });
 
             if (status === "error") {
                 setStatus("idle");
@@ -44,13 +59,45 @@ export default function ContactForm() {
             }
         };
 
+    const extractFieldErrors = (data: unknown): ContactFieldErrors => {
+        if (!data || typeof data !== "object" || !("fields" in data)) {
+            return {};
+        }
+
+        const fields = (data as { fields?: unknown }).fields;
+
+        if (!fields || typeof fields !== "object") {
+            return {};
+        }
+
+        const rawFields = fields as Record<string, unknown>;
+
+        return {
+            name: typeof rawFields.name === "string" ? rawFields.name : undefined,
+            email: typeof rawFields.email === "string" ? rawFields.email : undefined,
+            message: typeof rawFields.content === "string" ? rawFields.content : undefined,
+            recaptcha:
+                typeof rawFields.recaptchaToken === "string"
+                    ? rawFields.recaptchaToken
+                    : undefined,
+        };
+    };
+
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 
         setStatus("sending");
         setErrorMessage(null);
+        setFieldErrors({});
 
         try {
+            const token = await recaptchaRef.current?.execute();
+
+            if (!token) {
+                setFieldErrors({ recaptcha: "Please complete the reCAPTCHA challenge." });
+                throw new Error("Please complete the reCAPTCHA challenge.");
+            }
+
             const res = await fetch("/api/sendmail", {
                 method: "POST",
                 headers: {
@@ -60,11 +107,13 @@ export default function ContactForm() {
                     name: form.name,
                     email: form.email,
                     content: form.message,
+                    recaptchaToken: token,
                 }),
             });
 
             if (!res.ok) {
                 const data = await res.json().catch(() => null);
+                setFieldErrors(extractFieldErrors(data));
                 const message =
                     data && typeof data === "object" && "error" in data && typeof data.error === "string"
                         ? data.error
@@ -74,14 +123,22 @@ export default function ContactForm() {
 
             setStatus("success");
             setForm({ ...DEFAULT_FORM });
+            setFieldErrors({});
+            recaptchaRef.current?.reset();
         } catch (error) {
             console.error(error);
             setStatus("error");
-            setErrorMessage(
+            const message =
                 error instanceof Error && error.message
                     ? error.message
-                    : "メールの送信中にエラーが発生しました。"
+                    : "メールの送信中にエラーが発生しました。";
+            setErrorMessage(
+                message
             );
+            if (message.toLowerCase().includes("recaptcha")) {
+                setFieldErrors((prev) => ({ ...prev, recaptcha: message }));
+            }
+            recaptchaRef.current?.reset();
         }
     };
 
@@ -133,9 +190,16 @@ export default function ContactForm() {
                                     onChange={handleFieldChange("name")}
                                     placeholder="Your name"
                                     required
+                                    aria-invalid={Boolean(fieldErrors.name)}
+                                    aria-describedby={fieldErrors.name ? "name-error" : undefined}
                                     className="w-full rounded-xl border border-yellow-500/30 bg-white/70 px-10 py-3 text-black placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-1 focus:ring-offset-yellow-100 dark:border-yellow-500/30 dark:bg-white/10 dark:text-yellow-200 dark:placeholder-yellow-200 dark:focus:ring-yellow-400 dark:focus:ring-offset-0"
                                 />
                             </div>
+                            {fieldErrors.name && (
+                                <p id="name-error" className="mt-2 text-sm text-red-600 dark:text-red-400">
+                                    {fieldErrors.name}
+                                </p>
+                            )}
                         </div>
                         <div>
                             <label htmlFor="email" className="block mb-2 font-semibold">
@@ -150,9 +214,16 @@ export default function ContactForm() {
                                     onChange={handleFieldChange("email")}
                                     placeholder="you@example.com"
                                     required
+                                    aria-invalid={Boolean(fieldErrors.email)}
+                                    aria-describedby={fieldErrors.email ? "email-error" : undefined}
                                     className="w-full rounded-xl border border-yellow-500/30 bg-white/70 px-10 py-3 text-black placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-1 focus:ring-offset-yellow-100 dark:border-yellow-500/30 dark:bg-white/10 dark:text-yellow-200 dark:placeholder-yellow-200 dark:focus:ring-yellow-400 dark:focus:ring-offset-0"
                                 />
                             </div>
+                            {fieldErrors.email && (
+                                <p id="email-error" className="mt-2 text-sm text-red-600 dark:text-red-400">
+                                    {fieldErrors.email}
+                                </p>
+                            )}
                         </div>
                     </div>
 
@@ -170,13 +241,30 @@ export default function ContactForm() {
                                 rows={5}
                                 maxLength={500}
                                 required
+                                aria-invalid={Boolean(fieldErrors.message)}
+                                aria-describedby={fieldErrors.message ? "message-error" : undefined}
                                 className="w-full rounded-xl border border-yellow-500/30 bg-white/70 px-10 py-3 text-black placeholder-gray-500 shadow-sm focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-1 focus:ring-offset-yellow-100 dark:border-yellow-500/30 dark:bg-white/10 dark:text-yellow-200 dark:placeholder-yellow-200 dark:focus:ring-yellow-400 dark:focus:ring-offset-0"
                             />
                         </div>
+                        {fieldErrors.message && (
+                            <p id="message-error" className="mt-2 text-sm text-red-600 dark:text-red-400">
+                                {fieldErrors.message}
+                            </p>
+                        )}
                         <p className="text-sm text-right text-gray-600 dark:text-yellow-200">
                             {form.message.length}/500
                         </p>
                     </div>
+
+                    <Recaptcha
+                        ref={recaptchaRef}
+                        onChange={() => undefined}
+                    />
+                    {fieldErrors.recaptcha && (
+                        <p className="text-center text-sm text-red-600 dark:text-red-400">
+                            {fieldErrors.recaptcha}
+                        </p>
+                    )}
 
                     <button
                         type="submit"

--- a/app/components/ContactForm.tsx
+++ b/app/components/ContactForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { FiUser, FiMail, FiMessageSquare, FiSend, FiLoader, FiCheck, FiGithub } from "react-icons/fi";
 import { RiTwitterXLine, RiAccountCircleLine } from "react-icons/ri";
@@ -17,8 +17,6 @@ type ContactFieldErrors = Partial<
     Record<keyof ContactFormValues | "recaptcha", string>
 >;
 
-const ignoreRecaptchaChange = () => undefined;
-
 export default function ContactForm() {
     const [form, setForm] = useState(DEFAULT_FORM);
     const [status, setStatus] = useState<"idle" | "sending" | "success" | "error">("idle");
@@ -26,6 +24,7 @@ export default function ContactForm() {
     const [fieldErrors, setFieldErrors] = useState<ContactFieldErrors>({});
     const modalRef = useRef<HTMLDivElement>(null);
     const recaptchaRef = useRef<RecaptchaHandle>(null);
+    const handleRecaptchaChange = useCallback(() => undefined, []);
 
     useEffect(() => {
         if (status === "success" || status === "error") {
@@ -260,7 +259,7 @@ export default function ContactForm() {
 
                     <Recaptcha
                         ref={recaptchaRef}
-                        onChange={ignoreRecaptchaChange}
+                        onChange={handleRecaptchaChange}
                     />
                     {fieldErrors.recaptcha && (
                         <p className="text-center text-sm text-red-600 dark:text-red-400">


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/My-portfolio/issues/79

## 目的

問い合わせフォームに対して、フロントエンドとサーバーサイドの両方で最低限の入力検証・reCAPTCHA 検証・スパム対策を追加する。

## 実装内容

- 問い合わせ送信時に reCAPTCHA token を取得し、API に `recaptchaToken` として送信
- フロント側で `name` / `email` / `message` の空文字・空白のみ送信を抑止
- `email` 入力に `type="email"` を使い、ブラウザ標準の形式チェックを利用
- API レスポンスの `fields` をフォーム項目に対応付け、項目別エラーを表示
- サーバー側で request body を安全に parse し、trim 後の値で validation
- サーバー側で `name` / `email` / `content` / `recaptchaToken` の必須チェックを実施
- サーバー側で email 形式、name/email/content の最大文字数を検証
- サーバー側で reCAPTCHA token を Google `siteverify` API に送信して検証
- reCAPTCHA 失敗時はメール送信前に `403 Forbidden` で拒否
- reCAPTCHA verify に timeout を設定し、外部 API 停滞時は bounded に失敗させる
- IP ベースの簡易 rate limit を追加
- trusted proxy 環境では `cf-connecting-ip` / `x-real-ip` / `x-forwarded-for` から client IP を取得
- forwarded IP token の optional port / bracketed IP を正規化してから検証
- rate limit store の stale cleanup と bucket cap pruning を入れ、Map の肥大化を抑制
- バリデーションエラーを `{ error, fields }` 形式に整理

## 実装方法

- `ContactForm.tsx` で `Recaptcha` を ref 経由で実行し、取得した token を `recaptchaToken` として送信
- API の `fields.name` / `fields.email` / `fields.content` / `fields.recaptchaToken` をフォーム側の `name` / `email` / `message` / `recaptcha` エラーに対応付けて表示
- `route.ts` で request body を安全に parse し、想定外の JSON / object 以外の payload を `400 Bad Request` として扱う
- `route.ts` で trim 後の値を使って入力 validation を実行
- reCAPTCHA secret は `RECAPTCHA_SECRET_KEY` または `RECAPTCHA_SECRET` から読み込む
- Google `siteverify` へのリクエストは `AbortController` + timeout で制御し、timer は cleanup する
- rate limit はメモリ上の `Map` で client IP ごとの送信回数を制限
- client IP が取得できない場合は `anonymous:global` bucket に fallback
- trusted forwarded header は `TRUST_FORWARDED_IP_HEADERS`、または Vercel 環境で有効化する

## 変更箇所

- `app/components/ContactForm.tsx`
- `app/api/sendmail/route.ts`
- `app/components/Recaptcha.tsx`
- `app/api/recaptcha-config/route.ts`
- `lib/recaptcha.ts`

## まとめ

問い合わせフォームの送信処理に reCAPTCHA token 連携を追加し、サーバー側で入力検証・reCAPTCHA 検証・簡易 rate limit を通過した場合のみメール送信する形に変更しました。

エラー時は API から `{ error, fields }` 形式のレスポンスを返し、フロント側では項目別にエラーを表示します。reCAPTCHA verify の timeout、trusted proxy 配下での client IP 解決、rate limit store の上限管理も追加し、外部 API 停滞や高 cardinality traffic でもフォーム処理が不必要に不安定にならないようにしています。

## Testing

- `npm.cmd run build`
- 空白 `name` / 不正 `email` / 空白 `content` / 空 `recaptchaToken` の POST が `400 Bad Request` になることを確認
- 正しい入力値 + 不正 reCAPTCHA token の POST が `403 Forbidden` になることを確認
- build 後に `next-sitemap` が `public` 配下を更新する場合があるため、レビュー対象外の生成差分が混ざらないことを確認
