### PR TITLE
Hide visible reCAPTCHA challenge

### DIFF
--- a/app/components/ContactForm.tsx
+++ b/app/components/ContactForm.tsx
@@ -260,6 +260,7 @@ export default function ContactForm() {
                     <Recaptcha
                         ref={recaptchaRef}
                         onChange={handleRecaptchaChange}
+                        size="invisible"
                     />
                     {fieldErrors.recaptcha && (
                         <p className="text-center text-sm text-red-600 dark:text-red-400">
@@ -276,6 +277,28 @@ export default function ContactForm() {
                         {status === "idle" && <FiSend />}
                         {status === "sending" ? "Sending..." : "Send"}
                     </button>
+
+                    <p className="text-center text-[11px] leading-relaxed text-gray-500 dark:text-yellow-100/60">
+                        This site is protected by reCAPTCHA and the Google{" "}
+                        <a
+                            href="https://policies.google.com/privacy"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline underline-offset-2 hover:text-gray-700 dark:hover:text-yellow-100"
+                        >
+                            Privacy Policy
+                        </a>{" "}
+                        and{" "}
+                        <a
+                            href="https://policies.google.com/terms"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline underline-offset-2 hover:text-gray-700 dark:hover:text-yellow-100"
+                        >
+                            Terms of Service
+                        </a>{" "}
+                        apply.
+                    </p>
                 </form>
 
                 <div className="border-t border-yellow-500/30 pt-8 dark:border-yellow-500/40">

--- a/app/globals.css
+++ b/app/globals.css
@@ -32,6 +32,10 @@ body {
   background-attachment: fixed;
 }
 
+.grecaptcha-badge {
+  visibility: hidden;
+}
+
 a:focus-visible,
 button:focus-visible {
   outline: 2px solid #facc15;


### PR DESCRIPTION
 ## Issue

  reCAPTCHA のボット確認 UI を非表示にする

  ## 目的

  問い合わせフォームに表示される reCAPTCHA のボット確認 UI が画面上で目立ち、フォーム操作時の邪魔になっていたため、ユーザーに見えるチェック UI を表示せずに送信できるようにする。

  ## 実装内容

  - 問い合わせフォームの reCAPTCHA を invisible モードに変更
  - フォーム上に表示される reCAPTCHA のチェック UI を非表示化
  - 送信時の reCAPTCHA 実行処理は維持
  - 既存の問い合わせ送信処理や API 側の検証処理には影響しないように調整

  ## 実装方法

  - ContactForm.tsx で Recaptcha コンポーネントに size="invisible" を指定
  - reCAPTCHA の実行は既存どおり送信時に execute() で行う構成を維持
  - visible なチェックボックス表示だけを抑制し、スパム対策の処理自体は残す形に変更

  ## 変更箇所

  - ContactForm.tsx

  ## まとめ

  問い合わせフォーム内に表示されていた reCAPTCHA のボット確認 UI を invisible モードへ変更しました。これにより、フォーム画面上の邪魔な確認 UI は表示されなくなり、送信時の reCAPTCHA 検証処理はそのまま維持されます。

  ## Testing

  - npm.cmd test 成功
      - 4 test files
      - 10 tests passed
  - npm.cmd run build 成功